### PR TITLE
fix: SSE keep-alive, clean shutdown, MCP coverage (AUR-230/231/232)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { render } from "ink";
 import { App } from "./ui/App.js";
 import { restoreTerminal } from "./util/terminal.js";
+import { onShutdown, runShutdownHooks } from "./util/shutdown.js";
 
 const arg = process.argv[2];
 
@@ -118,12 +119,11 @@ if (arg === "serve") {
     },
   };
   const adapters = startAllAdapters(sink, workspace);
+  onShutdown(() => stopAllAdapters(adapters));
+  onShutdown(() => server.stop());
   process.stderr.write(`[agentwatch] serving ${server.url}\n`);
-  process.on("SIGINT", async () => {
-    stopAllAdapters(adapters);
-    await server.stop();
-    process.exit(0);
-  });
+  // Signal handling happens at the bottom of this file via the global
+  // shutdown-hooks wiring; the serve path just registers its cleanup.
   await new Promise(() => undefined);
 }
 
@@ -135,12 +135,41 @@ function parseFlag(name: string): string | undefined {
 }
 
 enterAltScreen();
-for (const sig of ["exit", "SIGINT", "SIGTERM", "SIGHUP"] as const) {
-  process.on(sig, () => {
-    restoreTerminal();
-    if (sig !== "exit") process.exit(0);
-  });
+
+/** Single shutdown path — restore the terminal, drain every registered
+ *  hook (adapters, web server, triggers watcher), then exit. Idempotent:
+ *  a second signal mid-drain is swallowed by `runShutdownHooks`. */
+let shuttingDown = false;
+async function shutdown(code: number): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  restoreTerminal();
+  try {
+    await runShutdownHooks();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[agentwatch] shutdown error:", err);
+  }
+  process.exit(code);
 }
 
-const { waitUntilExit } = render(<App />);
-waitUntilExit().finally(() => restoreTerminal());
+for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+  process.on(sig, () => {
+    void shutdown(0);
+  });
+}
+// `exit` fires synchronously and can't await — best-effort terminal reset.
+process.on("exit", () => {
+  restoreTerminal();
+});
+
+if (arg !== "serve") {
+  const { waitUntilExit } = render(<App />);
+  waitUntilExit()
+    .catch(() => {
+      // Ink sometimes rejects on Ctrl-C; shutdown handler covers it.
+    })
+    .finally(() => {
+      void shutdown(0);
+    });
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,33 +1,46 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
+import Database from "better-sqlite3";
 import { claudeProjectsDir } from "../util/workspace.js";
 import { codexSessionsDir, translateCodexLine } from "../adapters/codex.js";
 import { translateClaudeLine } from "../adapters/claude-code.js";
+import { translateSession as translateOpenClawLine } from "../adapters/openclaw.js";
+import {
+  translateHermesMessage,
+  translateHermesSessionEnd,
+  translateHermesSessionStart,
+  type HermesMessage,
+  type HermesSession,
+} from "../adapters/hermes.js";
 import type { AgentEvent } from "../schema.js";
 
 /**
  * agentwatch MCP server. Exposes the user's local agent history so
- * running agents (Claude Code, Cursor, Codex) can look up what they —
- * or other agents — did before. Turns agentwatch from "viewer" into
- * "cross-session memory substrate".
+ * running agents (Claude Code, Cursor, Codex, OpenClaw, Hermes) can
+ * look up what they — or other agents — did before. Turns agentwatch
+ * from "viewer" into "cross-session memory substrate".
  *
  * Transport: stdio. Run via `agentwatch mcp`.
  *
  * Tools:
- *   - list_recent_sessions   → [{agent, sessionId, project, lastActivity, events}]
+ *   - list_recent_sessions   → [{agent, sessionId, project, lastActivity, sizeBytes}]
  *   - get_session_events     → raw jsonl lines for a session
  *   - search_sessions        → grep across all session files
  *   - get_tool_usage_stats   → per-tool invocation counts + durations + errors
  *   - get_session_cost       → per-session cost, token breakdown, turn count
  */
 
+type McpAgent = "claude-code" | "codex" | "gemini" | "openclaw" | "hermes";
+
 interface SessionRef {
-  agent: "claude-code" | "codex" | "gemini";
+  agent: McpAgent;
   sessionId: string;
   project: string;
+  /** File path for JSONL agents; DB path for hermes. */
   path: string;
   lastActivity: number;
   sizeBytes: number;
@@ -44,7 +57,7 @@ export async function runMcpServer(): Promise<void> {
     {
       title: "List recent agent sessions",
       description:
-        "List the most recent local agent sessions across Claude Code and Codex, newest first. Use to find a session to inspect.",
+        "List the most recent local agent sessions across Claude Code, Codex, Gemini, OpenClaw, and Hermes, newest first. Use to find a session to inspect.",
       inputSchema: {
         limit: z.number().int().min(1).max(100).optional(),
       },
@@ -69,7 +82,7 @@ export async function runMcpServer(): Promise<void> {
     {
       title: "Get raw events for a session",
       description:
-        "Return the raw JSONL lines for a given session ID. Use after list_recent_sessions to drill into a session.",
+        "Return the raw events for a given session ID. JSONL for file-based agents (Claude/Codex/Gemini/OpenClaw); Hermes messages are serialized as one JSON object per line. Use after list_recent_sessions to drill into a session.",
       inputSchema: {
         sessionId: z.string(),
         maxBytes: z.number().int().min(1024).max(10_000_000).optional(),
@@ -86,12 +99,12 @@ export async function runMcpServer(): Promise<void> {
           ],
         };
       }
-      const raw = readFileSync(match.path, "utf8");
-      const trimmed =
-        raw.length > cap ? raw.slice(raw.length - cap) : raw;
-      return {
-        content: [{ type: "text", text: trimmed }],
-      };
+      const raw =
+        match.agent === "hermes"
+          ? dumpHermesSessionJsonl(match)
+          : safeReadFile(match.path);
+      const trimmed = raw.length > cap ? raw.slice(raw.length - cap) : raw;
+      return { content: [{ type: "text", text: trimmed }] };
     },
   );
 
@@ -100,7 +113,7 @@ export async function runMcpServer(): Promise<void> {
     {
       title: "Search across all sessions",
       description:
-        "Substring search across all local agent session files. Returns matching sessions with the first few matching lines.",
+        "Substring search across all local agent session files. Returns matching sessions with the first few matching lines. Covers Claude, Codex, Gemini, OpenClaw, and Hermes.",
       inputSchema: {
         query: z.string().min(1),
         limit: z.number().int().min(1).max(50).optional(),
@@ -112,20 +125,18 @@ export async function runMcpServer(): Promise<void> {
       const cap = limit ?? 20;
       for (const s of listAllSessions()) {
         if (out.length >= cap) break;
-        try {
-          const raw = readFileSync(s.path, "utf8");
-          for (const line of raw.split("\n")) {
-            if (line.toLowerCase().includes(needle)) {
-              out.push({
-                session: s.sessionId,
-                agent: s.agent,
-                line: line.slice(0, 500),
-              });
-              if (out.length >= cap) break;
-            }
+        const raw =
+          s.agent === "hermes" ? dumpHermesSessionJsonl(s) : safeReadFile(s.path);
+        if (!raw) continue;
+        for (const line of raw.split("\n")) {
+          if (line.toLowerCase().includes(needle)) {
+            out.push({
+              session: s.sessionId,
+              agent: s.agent,
+              line: line.slice(0, 500),
+            });
+            if (out.length >= cap) break;
           }
-        } catch {
-          /* skip unreadable */
         }
       }
       return {
@@ -272,16 +283,62 @@ export async function runMcpServer(): Promise<void> {
   await server.connect(transport);
 }
 
-/** Read a session file, translate every line via the relevant adapter,
+function safeReadFile(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/** Serialize a hermes session — the session row plus every message —
+ *  as one JSON object per line so `get_session_events` and
+ *  `search_sessions` can treat it like any other JSONL source. */
+function dumpHermesSessionJsonl(ref: SessionRef): string {
+  const db = openHermesDb(ref.path);
+  if (!db) return "";
+  try {
+    const session = db
+      .prepare("SELECT * FROM sessions WHERE id = ?")
+      .get(ref.sessionId) as Record<string, unknown> | undefined;
+    const messages = db
+      .prepare(
+        "SELECT id, session_id, role, content, tool_call_id, tool_calls, tool_name, " +
+          "timestamp, token_count, finish_reason, reasoning " +
+          "FROM messages WHERE session_id = ? ORDER BY id",
+      )
+      .all(ref.sessionId) as Record<string, unknown>[];
+    const lines: string[] = [];
+    if (session) lines.push(JSON.stringify({ kind: "session", ...session }));
+    for (const m of messages) lines.push(JSON.stringify({ kind: "message", ...m }));
+    return lines.join("\n");
+  } catch {
+    return "";
+  } finally {
+    try {
+      db.close();
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+function openHermesDb(path: string) {
+  try {
+    const db = new Database(path, { readonly: true, fileMustExist: true });
+    db.pragma("journal_mode = WAL");
+    db.pragma("busy_timeout = 2000");
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+/** Read a session, translate every line via the relevant adapter,
  *  and return AgentEvents. Unreadable / malformed lines are silently
  *  skipped. */
 function parseSession(s: SessionRef): AgentEvent[] {
-  let raw: string;
-  try {
-    raw = readFileSync(s.path, "utf8");
-  } catch {
-    return [];
-  }
+  if (s.agent === "hermes") return parseHermesSession(s);
   if (s.agent === "gemini") {
     // Gemini sessions are single-JSON not JSONL, and we don't yet
     // translate them to AgentEvents for stats purposes. Return empty
@@ -290,21 +347,70 @@ function parseSession(s: SessionRef): AgentEvent[] {
     // get_session_events.
     return [];
   }
+  const raw = safeReadFile(s.path);
+  if (!raw) return [];
   const out: AgentEvent[] = [];
   for (const line of raw.split("\n")) {
     if (!line.trim()) continue;
+    let obj: unknown;
     try {
-      const obj = JSON.parse(line);
-      const e =
-        s.agent === "claude-code"
-          ? translateClaudeLine(obj, s.sessionId, s.project)
-          : translateCodexLine(obj, s.sessionId, s.project);
-      if (e) out.push(e);
+      obj = JSON.parse(line);
     } catch {
-      /* malformed */
+      continue;
     }
+    if (!obj || typeof obj !== "object") continue;
+    const record = obj as Record<string, unknown>;
+    let e: AgentEvent | null = null;
+    if (s.agent === "claude-code")
+      e = translateClaudeLine(record, s.sessionId, s.project);
+    else if (s.agent === "codex")
+      e = translateCodexLine(record, s.sessionId, s.project);
+    else if (s.agent === "openclaw")
+      e = translateOpenClawLine(record, s.project || "unknown", s.sessionId);
+    if (e) out.push(e);
   }
   return out;
+}
+
+function parseHermesSession(s: SessionRef): AgentEvent[] {
+  const db = openHermesDb(s.path);
+  if (!db) return [];
+  try {
+    const session = db
+      .prepare(
+        "SELECT id, source, user_id, model, parent_session_id, started_at, ended_at, " +
+          "end_reason, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, " +
+          "actual_cost_usd, estimated_cost_usd FROM sessions WHERE id = ?",
+      )
+      .get(s.sessionId) as HermesSession | undefined;
+    const messages = db
+      .prepare(
+        "SELECT id, session_id, role, content, tool_call_id, tool_calls, tool_name, " +
+          "timestamp, token_count, finish_reason, reasoning " +
+          "FROM messages WHERE session_id = ? ORDER BY id",
+      )
+      .all(s.sessionId) as HermesMessage[];
+    const out: AgentEvent[] = [];
+    if (session) {
+      out.push(translateHermesSessionStart(session, s.path));
+      if (session.ended_at !== null) {
+        out.push(translateHermesSessionEnd(session, s.path));
+      }
+    }
+    for (const m of messages) {
+      const e = translateHermesMessage(m, s.path);
+      if (e) out.push(e);
+    }
+    return out;
+  } catch {
+    return [];
+  } finally {
+    try {
+      db.close();
+    } catch {
+      // best-effort
+    }
+  }
 }
 
 function listAllSessions(): SessionRef[] {
@@ -346,8 +452,111 @@ function listAllSessions(): SessionRef[] {
   } catch {
     /* no gemini */
   }
+  try {
+    walkOpenClaw(resolveOpenClawRoot(), out);
+  } catch {
+    /* no openclaw */
+  }
+  try {
+    walkHermes(resolveHermesDbPath(), out);
+  } catch {
+    /* no hermes */
+  }
   out.sort((a, b) => b.lastActivity - a.lastActivity);
   return out;
+}
+
+function resolveOpenClawRoot(): string {
+  return join(homedir(), ".openclaw");
+}
+
+function resolveHermesDbPath(): string {
+  const explicit = process.env.HERMES_DB_PATH?.trim();
+  if (explicit && explicit.length > 0) return explicit;
+  const hermesHome = process.env.HERMES_HOME?.trim();
+  const base =
+    hermesHome && hermesHome.length > 0
+      ? hermesHome
+      : join(homedir(), ".hermes");
+  return join(base, "state.db");
+}
+
+function walkOpenClaw(root: string, out: SessionRef[]): void {
+  if (!existsSync(root)) return;
+  const agentsDir = join(root, "agents");
+  let agents: string[];
+  try {
+    agents = readdirSync(agentsDir);
+  } catch {
+    return;
+  }
+  for (const agent of agents) {
+    const sessionsDir = join(agentsDir, agent, "sessions");
+    let files: string[];
+    try {
+      files = readdirSync(sessionsDir);
+    } catch {
+      continue;
+    }
+    for (const name of files) {
+      if (!name.endsWith(".jsonl")) continue;
+      const full = join(sessionsDir, name);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      out.push({
+        agent: "openclaw",
+        sessionId: name.replace(/\.jsonl$/, ""),
+        project: agent,
+        path: full,
+        lastActivity: st.mtimeMs,
+        sizeBytes: st.size,
+      });
+    }
+  }
+}
+
+function walkHermes(dbPath: string, out: SessionRef[]): void {
+  if (!existsSync(dbPath)) return;
+  const db = openHermesDb(dbPath);
+  if (!db) return;
+  try {
+    const st = statSync(dbPath);
+    type Row = {
+      id: string;
+      source: string | null;
+      message_count: number | null;
+      started_at: number;
+      ended_at: number | null;
+    };
+    const rows = db
+      .prepare(
+        "SELECT id, source, message_count, started_at, ended_at FROM sessions",
+      )
+      .all() as Row[];
+    for (const r of rows) {
+      const lastSec = r.ended_at ?? r.started_at;
+      out.push({
+        agent: "hermes",
+        sessionId: r.id,
+        project: r.source ?? "hermes",
+        path: dbPath,
+        lastActivity: Math.floor(lastSec * 1000) || st.mtimeMs,
+        sizeBytes: r.message_count ?? 0,
+      });
+    }
+  } catch {
+    /* best-effort */
+  } finally {
+    try {
+      db.close();
+    } catch {
+      // best-effort
+    }
+  }
 }
 
 function walkGemini(dir: string, out: SessionRef[]): void {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -132,18 +132,9 @@ export async function startServer(opts: StartServerOptions): Promise<ServerHandl
     reply.raw.setHeader("X-Accel-Buffering", "no");
     reply.raw.flushHeaders?.();
     const clientId = broadcaster.attach(reply.raw);
-    // Send a heartbeat every 15s so proxies don't kill idle conns.
-    const hb = setInterval(() => {
-      try {
-        reply.raw.write(": heartbeat\n\n");
-      } catch {
-        // client gone
-      }
-    }, 15_000);
-    req.raw.on("close", () => {
-      clearInterval(hb);
-      broadcaster.detach(clientId);
-    });
+    // Heartbeat is owned by the broadcaster — a single tick for N clients
+    // that shares dead-socket detection with `broadcast()`.
+    req.raw.on("close", () => broadcaster.detach(clientId));
     // Keep the handler alive until the socket closes.
     return reply;
   });

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { SseBroadcaster } from "./sse.js";
+
+function fakeRes(): {
+  writes: string[];
+  ended: boolean;
+  write: (chunk: string) => void;
+  end: () => void;
+  throwOnNextWrite?: boolean;
+} {
+  const obj: ReturnType<typeof fakeRes> = {
+    writes: [],
+    ended: false,
+    write(chunk: string) {
+      if (this.throwOnNextWrite) {
+        this.throwOnNextWrite = false;
+        throw new Error("socket gone");
+      }
+      this.writes.push(chunk);
+    },
+    end() {
+      this.ended = true;
+    },
+  };
+  return obj;
+}
+
+describe("SseBroadcaster", () => {
+  it("writes a hello frame on attach", () => {
+    const b = new SseBroadcaster();
+    const res = fakeRes();
+    b.attach(res as unknown as import("node:http").ServerResponse);
+    expect(res.writes[0]).toContain("event: hello");
+    b.closeAll();
+  });
+
+  it("emits heartbeat frames to all attached clients", () => {
+    const b = new SseBroadcaster();
+    const a = fakeRes();
+    const c = fakeRes();
+    b.attach(a as unknown as import("node:http").ServerResponse);
+    b.attach(c as unknown as import("node:http").ServerResponse);
+    b.pingForTest();
+    expect(a.writes.some((w) => w.includes(": heartbeat"))).toBe(true);
+    expect(c.writes.some((w) => w.includes(": heartbeat"))).toBe(true);
+    b.closeAll();
+  });
+
+  it("detaches clients whose heartbeat write throws", () => {
+    const b = new SseBroadcaster();
+    const good = fakeRes();
+    const dead = fakeRes();
+    b.attach(good as unknown as import("node:http").ServerResponse);
+    b.attach(dead as unknown as import("node:http").ServerResponse);
+    dead.throwOnNextWrite = true;
+    b.pingForTest();
+    expect(b.clientCount()).toBe(1);
+    // subsequent broadcast only reaches the good client
+    b.emitEvent({
+      id: "x",
+      ts: new Date().toISOString(),
+      agent: "claude-code",
+      type: "prompt",
+      sessionId: "s",
+      riskScore: 0,
+    });
+    expect(good.writes.some((w) => w.includes("event: event"))).toBe(true);
+    b.closeAll();
+  });
+
+  it("stops the heartbeat timer when the last client detaches", () => {
+    vi.useFakeTimers();
+    try {
+      const b = new SseBroadcaster(1_000);
+      const res = fakeRes();
+      const id = b.attach(res as unknown as import("node:http").ServerResponse);
+      expect(b.clientCount()).toBe(1);
+      b.detach(id);
+      expect(b.clientCount()).toBe(0);
+      // Advance past the interval — no new writes should land anywhere.
+      const writesBefore = res.writes.length;
+      vi.advanceTimersByTime(5_000);
+      expect(res.writes.length).toBe(writesBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -1,26 +1,46 @@
 import type { ServerResponse } from "node:http";
 import type { AgentEvent, EventDetails } from "../schema.js";
 
+/** Heartbeat cadence — below the usual 30–60 s idle-timeout on corporate
+ *  proxies and the default nginx/haproxy `proxy_read_timeout`. Comment
+ *  frames are ignored by EventSource clients but keep the TCP path warm. */
+const HEARTBEAT_MS = 15_000;
+const HEARTBEAT_FRAME = ": heartbeat\n\n";
+
 /** Minimal SSE broadcaster: one writable raw response per client.
- *  Drops clients on write failure; no retry, no buffering. */
+ *  Drops clients on write failure; no retry, no buffering.
+ *
+ *  Owns a single shared heartbeat interval — one timer for N clients.
+ *  When a write fails (heartbeat or broadcast), the client is detached
+ *  in one place. Previous design had a per-connection `setInterval` in
+ *  the route handler that only cleared on the socket `close` event, so
+ *  a broadcaster-detached zombie would keep ticking. */
 export class SseBroadcaster {
   private clients = new Map<number, ServerResponse>();
   private nextId = 0;
+  private heartbeat: NodeJS.Timeout | null = null;
+  private readonly intervalMs: number;
+
+  constructor(intervalMs: number = HEARTBEAT_MS) {
+    this.intervalMs = intervalMs;
+  }
 
   attach(res: ServerResponse): number {
     const id = this.nextId++;
     this.clients.set(id, res);
-    // Send a hello so the client can confirm the stream is live.
     try {
       res.write(`event: hello\ndata: {"ok":true}\n\n`);
     } catch {
       this.clients.delete(id);
+      return id;
     }
+    this.ensureHeartbeat();
     return id;
   }
 
   detach(id: number): void {
     this.clients.delete(id);
+    if (this.clients.size === 0) this.stopHeartbeat();
   }
 
   emitEvent(event: AgentEvent): void {
@@ -39,6 +59,15 @@ export class SseBroadcaster {
     this.broadcast("anomaly", { sessionId, headline });
   }
 
+  /** Test hook: force a heartbeat tick without waiting on the timer. */
+  pingForTest(): void {
+    this.tick();
+  }
+
+  clientCount(): number {
+    return this.clients.size;
+  }
+
   private broadcast(kind: string, data: unknown): void {
     const payload = `event: ${kind}\ndata: ${JSON.stringify(data)}\n\n`;
     for (const [id, res] of this.clients) {
@@ -48,9 +77,36 @@ export class SseBroadcaster {
         this.clients.delete(id);
       }
     }
+    if (this.clients.size === 0) this.stopHeartbeat();
+  }
+
+  private tick(): void {
+    for (const [id, res] of this.clients) {
+      try {
+        res.write(HEARTBEAT_FRAME);
+      } catch {
+        this.clients.delete(id);
+      }
+    }
+    if (this.clients.size === 0) this.stopHeartbeat();
+  }
+
+  private ensureHeartbeat(): void {
+    if (this.heartbeat) return;
+    this.heartbeat = setInterval(() => this.tick(), this.intervalMs);
+    // Don't hold the event loop open for a broadcaster with no external
+    // work — lets `process.exit()` on SIGINT actually exit.
+    this.heartbeat.unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeat) return;
+    clearInterval(this.heartbeat);
+    this.heartbeat = null;
   }
 
   closeAll(): void {
+    this.stopHeartbeat();
     for (const res of this.clients.values()) {
       try {
         res.end();

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,6 @@ import { Timeline } from "./Timeline.js";
 import { AgentPanel } from "./AgentPanel.js";
 import { Header } from "./Header.js";
 import { Breadcrumb } from "./Breadcrumb.js";
-import { restoreTerminal } from "../util/terminal.js";
 import { computeBudgetStatus } from "../util/budgets.js";
 import { emitEventSpan, initOtel, otelEnabled } from "../util/otel.js";
 import { watchTriggers } from "../util/triggers.js";
@@ -25,6 +24,7 @@ import { detectWorkspaceRoot } from "../util/workspace.js";
 import { initialState, matchesQuery, reducer } from "./state.js";
 import { startServer, type ServerHandle, addEventToServer } from "../server/index.js";
 import { openUrl } from "../util/open-url.js";
+import { onShutdown } from "../util/shutdown.js";
 
 /**
  * agentwatch TUI — live log tail.
@@ -57,6 +57,7 @@ export function App() {
     const host = findFlag("--host") ?? process.env.AGENTWATCH_HOST ?? "127.0.0.1";
     let handle: ServerHandle | null = null;
     let cancelled = false;
+    let unregister: (() => void) | null = null;
     startServer({ host, port, events })
       .then((h) => {
         if (cancelled) {
@@ -65,6 +66,7 @@ export function App() {
         }
         handle = h;
         setServer(h);
+        unregister = onShutdown(() => h.stop());
       })
       .catch((err) => {
         // eslint-disable-next-line no-console
@@ -72,6 +74,7 @@ export function App() {
       });
     return () => {
       cancelled = true;
+      unregister?.();
       if (handle) void handle.stop();
     };
   }, []);
@@ -131,7 +134,13 @@ export function App() {
       },
     };
     const adapters = startAllAdapters(sink, workspace);
+    const unregisterShutdown = onShutdown(() => {
+      flush();
+      stopAllAdapters(adapters);
+      stopTriggersWatch();
+    });
     return () => {
+      unregisterShutdown();
       flush();
       stopAllAdapters(adapters);
       stopTriggersWatch();
@@ -252,9 +261,10 @@ export function App() {
 
   useInput((input, key) => {
     if (key.ctrl && input === "c") {
+      // `exit()` unmounts ink, which triggers our useEffect cleanup
+      // (stopAllAdapters etc). waitUntilExit().finally in index.tsx
+      // drains the global shutdown hooks before process.exit.
       exit();
-      restoreTerminal();
-      setImmediate(() => process.exit(0));
       return;
     }
     if (state.searchOpen) {
@@ -277,8 +287,6 @@ export function App() {
     }
     if (input === "q") {
       exit();
-      restoreTerminal();
-      setImmediate(() => process.exit(0));
       return;
     }
     if (input === "w" && server) {

--- a/src/util/shutdown.test.ts
+++ b/src/util/shutdown.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetShutdownForTest,
+  onShutdown,
+  runShutdownHooks,
+} from "./shutdown.js";
+
+describe("shutdown registry", () => {
+  beforeEach(() => {
+    _resetShutdownForTest();
+  });
+
+  it("runs hooks in LIFO order", async () => {
+    const calls: number[] = [];
+    onShutdown(() => {
+      calls.push(1);
+    });
+    onShutdown(() => {
+      calls.push(2);
+    });
+    onShutdown(() => {
+      calls.push(3);
+    });
+    await runShutdownHooks();
+    expect(calls).toEqual([3, 2, 1]);
+  });
+
+  it("continues when a hook throws", async () => {
+    const calls: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    onShutdown(() => {
+      calls.push("first");
+    });
+    onShutdown(() => {
+      throw new Error("boom");
+    });
+    onShutdown(() => {
+      calls.push("third");
+    });
+    await runShutdownHooks();
+    expect(calls).toEqual(["third", "first"]);
+    spy.mockRestore();
+  });
+
+  it("awaits async hooks", async () => {
+    let done = false;
+    onShutdown(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      done = true;
+    });
+    await runShutdownHooks();
+    expect(done).toBe(true);
+  });
+
+  it("is idempotent on re-entry", async () => {
+    let count = 0;
+    onShutdown(() => {
+      count += 1;
+    });
+    await Promise.all([runShutdownHooks(), runShutdownHooks()]);
+    expect(count).toBe(1);
+  });
+
+  it("unregister removes a hook before it runs", async () => {
+    let ran = false;
+    const off = onShutdown(() => {
+      ran = true;
+    });
+    off();
+    await runShutdownHooks();
+    expect(ran).toBe(false);
+  });
+});

--- a/src/util/shutdown.ts
+++ b/src/util/shutdown.ts
@@ -1,0 +1,50 @@
+/**
+ * Process-wide shutdown registry.
+ *
+ * Adapters and the web server register synchronous cleanup functions
+ * here. When a signal arrives (SIGINT / SIGTERM / SIGHUP) or the TUI
+ * exits, `runShutdownHooks` drains the registry in LIFO order so
+ * chokidar watchers close, better-sqlite3 handles flush, and SSE
+ * sockets get a clean `end()` before the process dies.
+ *
+ * Previously: adapters were started inside React useEffect and only
+ * torn down by the unmount path. A SIGINT-driven `process.exit(0)`
+ * skipped React entirely, orphaning fs watchers and SQLite readers
+ * (and, on some systems, leaving the terminal in alt-screen mode).
+ */
+
+type Hook = () => void | Promise<void>;
+
+const hooks: Hook[] = [];
+let draining = false;
+
+export function onShutdown(fn: Hook): () => void {
+  hooks.push(fn);
+  return () => {
+    const i = hooks.lastIndexOf(fn);
+    if (i !== -1) hooks.splice(i, 1);
+  };
+}
+
+/** Run every registered hook, newest first, swallowing per-hook errors
+ *  so one failing adapter doesn't strand the others. Idempotent — a
+ *  second call is a no-op (a signal can arrive during cleanup). */
+export async function runShutdownHooks(): Promise<void> {
+  if (draining) return;
+  draining = true;
+  while (hooks.length > 0) {
+    const fn = hooks.pop()!;
+    try {
+      await fn();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[agentwatch] shutdown hook failed:", err);
+    }
+  }
+}
+
+/** Test helper — reset state between specs. */
+export function _resetShutdownForTest(): void {
+  hooks.length = 0;
+  draining = false;
+}


### PR DESCRIPTION
## Summary

- **AUR-230 — SSE keep-alive**: `SseBroadcaster` now owns a single shared 15s heartbeat interval. Dead-socket detection is centralized: broadcast + tick detach through one path, so a write failure can't leave the timer pinging a zombie socket.
- **AUR-231 — Clean shutdown**: adapters and the web server were only torn down on React unmount; SIGINT/SIGTERM called `process.exit(0)` before cleanup, orphaning chokidar watchers and better-sqlite3 handles. Added `util/shutdown.ts` (LIFO, idempotent, per-hook error isolation); `App.tsx` + serve mode register stoppers; `index.tsx` signal handlers drain the registry before exit.
- **AUR-232 — MCP coverage**: `list_recent_sessions` / `search_sessions` / `get_session_events` / `get_tool_usage_stats` / `get_session_cost` now include OpenClaw (`~/.openclaw/agents/*/sessions/*.jsonl`) and Hermes (`~/.hermes/state.db`). Hermes sessions are serialized as one JSON object per line for parity with JSONL agents.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 235 tests pass (added `sse.test.ts`, `shutdown.test.ts`)
- [x] `npm run build` clean
- [x] Smoke: `agentwatch mcp` → `list_recent_sessions` returns all 5 agents (51 claude, 13 openclaw, 18 gemini, 12 codex, 6 hermes)
- [x] Smoke: `get_session_events` on a hermes session returns session+message rows as JSONL
- [ ] Manual: start `agentwatch`, verify browser SSE survives >30s idle
- [ ] Manual: Ctrl-C `agentwatch`, verify no orphaned chokidar watchers (`lsof | grep agentwatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)