### PR TITLE
fix(adapters): preserve partial JSONL lines across reads (AUR-227)

### DIFF
--- a/src/adapters/claude-code.test.ts
+++ b/src/adapters/claude-code.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { translateClaudeLine } from "./claude-code.js";
+import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
 
 describe("translateClaudeLine", () => {
   it("emits a prompt event for a user message", () => {
@@ -61,5 +71,63 @@ describe("translateClaudeLine", () => {
   it("returns null for tool_result noise", () => {
     expect(translateClaudeLine({ type: "tool_result" }, "sess-1")).toBeNull();
     expect(translateClaudeLine({ type: "summary" }, "sess-1")).toBeNull();
+  });
+});
+
+describe("claude-code adapter — partial-line streaming (AUR-227)", () => {
+  it("recovers a JSONL line that was flushed across two reads", () => {
+    // Reproduces the bug: producer writes the first half of a JSON line,
+    // we read up to size, then the rest of the line is appended. Under
+    // the old readline-based loop the partial line was parsed (and lost
+    // on JSON.parse failure) AND the cursor advanced past it, so the
+    // second read couldn't find it. With the AUR-227 fix the cursor
+    // stays at the start of the unterminated tail until a full line is
+    // available.
+    const dir = mkdtempSync(join(tmpdir(), "aw-claude-"));
+    const session = join(dir, "session.jsonl");
+    const firstHalf =
+      '{"type":"user","timestamp":"2026-04-25T10:00:00Z","message":{"role":"user","content":"hello world from a chunk';
+    writeFileSync(session, firstHalf);
+
+    // First read at the partial flush: nothing terminated → 0 consumed.
+    const sz1 = statSync(session).size;
+    const first = readNewlineTerminatedLines(session, 0, sz1 - 1);
+    expect(first.lines).toHaveLength(0);
+    expect(first.consumed).toBe(0);
+
+    // Producer flushes the rest.
+    appendFileSync(session, ' that should arrive intact"}}\n');
+
+    const sz2 = statSync(session).size;
+    const second = readNewlineTerminatedLines(
+      session,
+      first.consumed,
+      sz2 - 1,
+    );
+    expect(second.lines).toHaveLength(1);
+    const parsed = JSON.parse(second.lines[0]!);
+    expect(parsed.message.content).toBe(
+      "hello world from a chunk that should arrive intact",
+    );
+    expect(first.consumed + second.consumed).toBe(sz2);
+  });
+
+  it("does not advance the cursor past an unterminated tail", () => {
+    const dir = mkdtempSync(join(tmpdir(), "aw-claude-"));
+    mkdirSync(dir, { recursive: true });
+    const session = join(dir, "s.jsonl");
+    // One terminated line + one partial line.
+    writeFileSync(session, '{"a":1}\n{"b":2,"c":');
+
+    const sz = statSync(session).size;
+    const { lines, consumed } = readNewlineTerminatedLines(
+      session,
+      0,
+      sz - 1,
+    );
+    expect(lines).toEqual(['{"a":1}']);
+    // Cursor sits at the start of the partial line (after the first \n),
+    // so when the rest arrives we re-read from there.
+    expect(consumed).toBe(8);
   });
 });

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,6 +1,5 @@
 import chokidar from "chokidar";
-import { createReadStream, existsSync, statSync } from "node:fs";
-import { createInterface } from "node:readline";
+import { existsSync, statSync } from "node:fs";
 import { basename, sep } from "node:path";
 import type { AgentEvent, EventType, EventSink } from "../schema.js";
 import { clampTs, riskOf } from "../schema.js";
@@ -10,6 +9,7 @@ import { detectAgentCall } from "../util/agent-call.js";
 import { registerSpawn } from "../util/spawn-tracker.js";
 import { costOf, parseUsage } from "../util/cost.js";
 import { markAgentWrite } from "../util/recent-writes.js";
+import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
 
 type Emit = EventSink | ((e: AgentEvent) => void);
 
@@ -76,84 +76,78 @@ export function startClaudeAdapter(sink: Emit): () => void {
     if (size <= cursor.offset) return;
 
     const start = cursor.offset;
-    const stream = createReadStream(file, {
-      start,
-      end: size - 1,
-      encoding: "utf8",
-    });
-
     const sessionId = basename(file, ".jsonl");
     const project = extractProject(file);
     const subAgentId = isSub ? extractSubAgentId(file) : undefined;
-    let consumed = 0;
-    let skippedFirst = false;
-    const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
-    rl.on("line", (line) => {
-      consumed += Buffer.byteLength(line, "utf8") + 1;
-      if (isInitialAdd && start > 0 && !skippedFirst) {
-        skippedFirst = true;
-        return;
-      }
-      if (!line.trim()) return;
+    const { lines, consumed } = readNewlineTerminatedLines(
+      file,
+      start,
+      size - 1,
+    );
+    cursor.offset = start + consumed;
+
+    for (let i = 0; i < lines.length; i++) {
+      // First line after a mid-file seek is a partial line; skip once.
+      if (i === 0 && isInitialAdd && start > 0) continue;
+      const line = lines[i]!;
+      if (!line.trim()) continue;
+      let obj: unknown;
       try {
-        const obj = JSON.parse(line);
-        // First, harvest any tool_result blocks from user turns — they
-        // correlate back to earlier tool_use events by tool_use_id.
-        handleToolResults(obj, enrich);
-
-        const event = translateClaudeLine(obj, sessionId, project, subAgentId);
-        if (event) {
-          emit(event);
-          // AUR-200: when this event invokes a child agent (codex/gemini/…),
-          // register the spawn so we can chain-link the child session.
-          if (event.details?.agentCall) {
-            const cwd =
-              typeof obj.cwd === "string" ? obj.cwd : "";
-            registerSpawn({
-              parentEventId: event.id,
-              callee: event.details.agentCall.callee,
-              cwd,
-              registeredMs: new Date(event.ts).getTime(),
-            });
-          }
-          // Mark attributed writes so the fs-watcher can dedupe.
-          if (
-            event.path &&
-            (event.type === "file_write" || event.type === "file_read")
-          ) {
-            markAgentWrite(event.path, event.ts);
-          }
-          // If this event is a tool_use whose result already arrived
-          // (backfill ordering quirk), attach it immediately.
-          const toolUseId = event.details?.toolUseId;
-          if (toolUseId && orphanResults.has(toolUseId)) {
-            const orphan = orphanResults.get(toolUseId)!;
-            orphanResults.delete(toolUseId);
-            enrich(event.id, {
-              toolResult: orphan.content,
-              toolError: orphan.isError,
-              durationMs: Math.max(
-                0,
-                new Date(orphan.ts).getTime() - new Date(event.ts).getTime(),
-              ),
-            });
-          } else if (toolUseId) {
-            pendingToolUses.set(toolUseId, {
-              eventId: event.id,
-              ts: event.ts,
-            });
-            capMap(pendingToolUses, MAX_PENDING_TOOL_USES);
-          }
-        }
+        obj = JSON.parse(line);
       } catch {
-        // ignore malformed lines
+        continue;
       }
-    });
+      // First, harvest any tool_result blocks from user turns — they
+      // correlate back to earlier tool_use events by tool_use_id.
+      handleToolResults(obj, enrich);
 
-    rl.on("close", () => {
-      cursor!.offset = start + consumed;
-    });
+      const event = translateClaudeLine(obj, sessionId, project, subAgentId);
+      if (!event) continue;
+      emit(event);
+      // AUR-200: when this event invokes a child agent (codex/gemini/…),
+      // register the spawn so we can chain-link the child session.
+      if (event.details?.agentCall) {
+        const cwd =
+          typeof (obj as Record<string, unknown>).cwd === "string"
+            ? ((obj as Record<string, unknown>).cwd as string)
+            : "";
+        registerSpawn({
+          parentEventId: event.id,
+          callee: event.details.agentCall.callee,
+          cwd,
+          registeredMs: new Date(event.ts).getTime(),
+        });
+      }
+      // Mark attributed writes so the fs-watcher can dedupe.
+      if (
+        event.path &&
+        (event.type === "file_write" || event.type === "file_read")
+      ) {
+        markAgentWrite(event.path, event.ts);
+      }
+      // If this event is a tool_use whose result already arrived
+      // (backfill ordering quirk), attach it immediately.
+      const toolUseId = event.details?.toolUseId;
+      if (toolUseId && orphanResults.has(toolUseId)) {
+        const orphan = orphanResults.get(toolUseId)!;
+        orphanResults.delete(toolUseId);
+        enrich(event.id, {
+          toolResult: orphan.content,
+          toolError: orphan.isError,
+          durationMs: Math.max(
+            0,
+            new Date(orphan.ts).getTime() - new Date(event.ts).getTime(),
+          ),
+        });
+      } else if (toolUseId) {
+        pendingToolUses.set(toolUseId, {
+          eventId: event.id,
+          ts: event.ts,
+        });
+        capMap(pendingToolUses, MAX_PENDING_TOOL_USES);
+      }
+    }
   };
 
   watcher.on("add", (f) => process(f, true));

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -1,6 +1,5 @@
 import chokidar from "chokidar";
-import { createReadStream, existsSync, statSync } from "node:fs";
-import { createInterface } from "node:readline";
+import { existsSync, statSync } from "node:fs";
 import { basename, join, sep } from "node:path";
 import os from "node:os";
 import type { AgentEvent, EventSink, EventType } from "../schema.js";
@@ -8,6 +7,7 @@ import { clampTs, riskOf } from "../schema.js";
 import { nextId } from "../util/ids.js";
 import { costOf } from "../util/cost.js";
 import { consumeSpawn } from "../util/spawn-tracker.js";
+import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
 
 const BACKFILL_BYTES = 4 * 1024 * 1024;
 
@@ -67,153 +67,143 @@ export function startCodexAdapter(sink: EventSink): () => void {
 
     const start = cursor.offset;
     const sessionId = extractSessionId(file);
-    const stream = createReadStream(file, {
+    const { lines, consumed } = readNewlineTerminatedLines(
+      file,
       start,
-      end: size - 1,
-      encoding: "utf8",
-    });
-    let consumed = 0;
-    let skippedFirst = false;
-    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+      size - 1,
+    );
+    cursor.offset = start + consumed;
 
-    rl.on("line", (line) => {
-      consumed += Buffer.byteLength(line, "utf8") + 1;
-      if (isInitialAdd && start > 0 && !skippedFirst) {
-        // First partial line after mid-file seek — skip.
-        skippedFirst = true;
-        return;
-      }
-      if (!line.trim()) return;
+    for (let i = 0; i < lines.length; i++) {
+      if (i === 0 && isInitialAdd && start > 0) continue;
+      const line = lines[i]!;
+      if (!line.trim()) continue;
+      let obj: Record<string, unknown>;
       try {
-        const obj = JSON.parse(line);
-        if (obj.type === "session_meta") {
-          const cwd = obj.payload?.cwd;
-          if (typeof cwd === "string") {
-            cursor!.project = projectOf(cwd);
-            cursor!.cwd = cwd;
-            // AUR-200: was this Codex session spawned by a `codex exec`
-            // call from another agent? If so, the next event we emit
-            // should carry the parent linkage.
-            const ts = typeof obj.timestamp === "string" ? obj.timestamp : "";
-            const parent = consumeSpawn(
-              "codex",
-              cwd,
-              ts ? new Date(ts).getTime() : Date.now(),
-            );
-            if (parent) cursor!.pendingParentSpawnId = parent.parentEventId;
-          }
-          const model = obj.payload?.model;
-          if (typeof model === "string") cursor!.model = model;
-          return;
-        }
-        if (obj.type === "turn_context") {
-          const model = obj.payload?.model;
-          if (typeof model === "string") cursor!.model = model;
-          return;
-        }
-        // Pair event_msg/token_count with the previous response event.
-        if (obj.type === "event_msg") {
-          const usage = extractTokenUsage(obj);
-          if (usage && cursor!.lastResponseId) {
-            const key = `${usage.input}|${usage.cacheRead}|${usage.output}`;
-            if (cursor!.lastUsageKey !== key) {
-              cursor!.lastUsageKey = key;
-              const model = cursor!.model ?? "gpt-5";
-              const cost = costOf(model, usage);
-              sink.enrich(cursor!.lastResponseId, { usage, cost, model });
-            }
-          }
-          // Codex signals compaction via task_started/turn_truncated —
-          // the equivalent of Claude's isCompactSummary.
-          if (isCompactionEvent(obj)) {
-            sink.emit({
-              id: nextId(),
-              ts: clampTs(
-                typeof obj.timestamp === "string"
-                  ? obj.timestamp
-                  : new Date().toISOString(),
-              ),
-              agent: "codex",
-              type: "compaction",
-              sessionId,
-              riskScore: riskOf("compaction"),
-              summary: `[${cursor!.project}] ⋈ context compacted`,
-            });
-          }
-          return;
-        }
-        // Handle function_call_output — pair with a pending tool event.
-        const payload = (obj.payload ?? {}) as Record<string, unknown>;
-        if (
-          obj.type === "response_item" &&
-          payload.type === "function_call_output"
-        ) {
-          const callId =
-            typeof payload.call_id === "string" ? payload.call_id : "";
-          const pend = callId ? cursor!.pendingCalls.get(callId) : undefined;
-          if (pend) {
-            cursor!.pendingCalls.delete(callId);
-            const out = payload.output;
-            const outText =
-              typeof out === "string"
-                ? out
-                : out && typeof out === "object"
-                  ? String(
-                      (out as Record<string, unknown>).content ??
-                        JSON.stringify(out),
-                    )
-                  : "";
-            const isError =
-              !!out &&
-              typeof out === "object" &&
-              (out as Record<string, unknown>).status === "error";
-            const ts = typeof obj.timestamp === "string" ? obj.timestamp : "";
-            const duration = ts
-              ? Math.max(0, new Date(ts).getTime() - pend.startMs)
-              : undefined;
-            sink.enrich(pend.eventId, {
-              toolResult: outText.slice(0, 50_000),
-              toolError: isError,
-              ...(duration != null ? { durationMs: duration } : {}),
-            });
-          }
-          return;
-        }
-
-        const event = translate(obj, sessionId, cursor!.project);
-        if (event) {
-          // AUR-200: stamp the first event of a spawned session with its
-          // parent agent_call event id, then clear the pending pointer.
-          if (cursor!.pendingParentSpawnId) {
-            event.details = {
-              ...(event.details ?? {}),
-              parentSpawnId: cursor!.pendingParentSpawnId,
-            };
-            cursor!.pendingParentSpawnId = undefined;
-          }
-          sink.emit(event);
-          if (event.type === "response") cursor!.lastResponseId = event.id;
-          // Track function_call events by call_id for later pairing.
-          const cid = event.details?.toolUseId;
-          if (cid && event.type !== "response" && event.type !== "prompt") {
-            cursor!.pendingCalls.set(cid, {
-              eventId: event.id,
-              startMs: new Date(event.ts).getTime(),
-            });
-            if (cursor!.pendingCalls.size > MAX_PENDING) {
-              const firstKey = cursor!.pendingCalls.keys().next().value;
-              if (firstKey !== undefined) cursor!.pendingCalls.delete(firstKey);
-            }
-          }
-        }
+        obj = JSON.parse(line) as Record<string, unknown>;
       } catch {
-        /* malformed line */
+        continue;
       }
-    });
+      const payload = (obj.payload ?? {}) as Record<string, unknown>;
+      if (obj.type === "session_meta") {
+        const cwd = payload.cwd;
+        if (typeof cwd === "string") {
+          cursor.project = projectOf(cwd);
+          cursor.cwd = cwd;
+          // AUR-200: was this Codex session spawned by a `codex exec`
+          // call from another agent? If so, the next event we emit
+          // should carry the parent linkage.
+          const ts = typeof obj.timestamp === "string" ? obj.timestamp : "";
+          const parent = consumeSpawn(
+            "codex",
+            cwd,
+            ts ? new Date(ts).getTime() : Date.now(),
+          );
+          if (parent) cursor.pendingParentSpawnId = parent.parentEventId;
+        }
+        const model = payload.model;
+        if (typeof model === "string") cursor.model = model;
+        continue;
+      }
+      if (obj.type === "turn_context") {
+        const model = payload.model;
+        if (typeof model === "string") cursor.model = model;
+        continue;
+      }
+      // Pair event_msg/token_count with the previous response event.
+      if (obj.type === "event_msg") {
+        const usage = extractTokenUsage(obj);
+        if (usage && cursor.lastResponseId) {
+          const key = `${usage.input}|${usage.cacheRead}|${usage.output}`;
+          if (cursor.lastUsageKey !== key) {
+            cursor.lastUsageKey = key;
+            const model = cursor.model ?? "gpt-5";
+            const cost = costOf(model, usage);
+            sink.enrich(cursor.lastResponseId, { usage, cost, model });
+          }
+        }
+        // Codex signals compaction via task_started/turn_truncated —
+        // the equivalent of Claude's isCompactSummary.
+        if (isCompactionEvent(obj)) {
+          sink.emit({
+            id: nextId(),
+            ts: clampTs(
+              typeof obj.timestamp === "string"
+                ? obj.timestamp
+                : new Date().toISOString(),
+            ),
+            agent: "codex",
+            type: "compaction",
+            sessionId,
+            riskScore: riskOf("compaction"),
+            summary: `[${cursor.project}] ⋈ context compacted`,
+          });
+        }
+        continue;
+      }
+      // Handle function_call_output — pair with a pending tool event.
+      if (
+        obj.type === "response_item" &&
+        payload.type === "function_call_output"
+      ) {
+        const callId =
+          typeof payload.call_id === "string" ? payload.call_id : "";
+        const pend = callId ? cursor.pendingCalls.get(callId) : undefined;
+        if (pend) {
+          cursor.pendingCalls.delete(callId);
+          const out = payload.output;
+          const outText =
+            typeof out === "string"
+              ? out
+              : out && typeof out === "object"
+                ? String(
+                    (out as Record<string, unknown>).content ??
+                      JSON.stringify(out),
+                  )
+                : "";
+          const isError =
+            !!out &&
+            typeof out === "object" &&
+            (out as Record<string, unknown>).status === "error";
+          const ts = typeof obj.timestamp === "string" ? obj.timestamp : "";
+          const duration = ts
+            ? Math.max(0, new Date(ts).getTime() - pend.startMs)
+            : undefined;
+          sink.enrich(pend.eventId, {
+            toolResult: outText.slice(0, 50_000),
+            toolError: isError,
+            ...(duration != null ? { durationMs: duration } : {}),
+          });
+        }
+        continue;
+      }
 
-    rl.on("close", () => {
-      cursor!.offset = start + consumed;
-    });
+      const event = translate(obj, sessionId, cursor.project);
+      if (!event) continue;
+      // AUR-200: stamp the first event of a spawned session with its
+      // parent agent_call event id, then clear the pending pointer.
+      if (cursor.pendingParentSpawnId) {
+        event.details = {
+          ...(event.details ?? {}),
+          parentSpawnId: cursor.pendingParentSpawnId,
+        };
+        cursor.pendingParentSpawnId = undefined;
+      }
+      sink.emit(event);
+      if (event.type === "response") cursor.lastResponseId = event.id;
+      // Track function_call events by call_id for later pairing.
+      const cid = event.details?.toolUseId;
+      if (cid && event.type !== "response" && event.type !== "prompt") {
+        cursor.pendingCalls.set(cid, {
+          eventId: event.id,
+          startMs: new Date(event.ts).getTime(),
+        });
+        if (cursor.pendingCalls.size > MAX_PENDING) {
+          const firstKey = cursor.pendingCalls.keys().next().value;
+          if (firstKey !== undefined) cursor.pendingCalls.delete(firstKey);
+        }
+      }
+    }
   };
 
   watcher.on("add", (f) => handle(f, true));

--- a/src/adapters/openclaw.ts
+++ b/src/adapters/openclaw.ts
@@ -1,11 +1,11 @@
 import chokidar from "chokidar";
-import { createReadStream, existsSync, readFileSync, statSync } from "node:fs";
-import { createInterface } from "node:readline";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename, join, sep } from "node:path";
 import { homedir } from "node:os";
 import type { AgentEvent, EventType } from "../schema.js";
 import { clampTs, riskOf } from "../schema.js";
 import { nextId } from "../util/ids.js";
+import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
 import {
   classifySessionKey,
   type ScheduledMarker,
@@ -186,26 +186,17 @@ function streamLines(
   if (size <= cursor.offset) return;
 
   const start = cursor.offset;
-  const stream = createReadStream(file, {
+  const { lines, consumed } = readNewlineTerminatedLines(
+    file,
     start,
-    end: size - 1,
-    encoding: "utf8",
-  });
-  let consumed = 0;
-  let skippedFirst = false;
-  const rl = createInterface({ input: stream, crlfDelay: Infinity });
-  rl.on("line", (line) => {
-    consumed += Buffer.byteLength(line, "utf8") + 1;
-    // If we started mid-file, drop the first (likely partial) line
-    if (isInitialAdd && start > 0 && !skippedFirst) {
-      skippedFirst = true;
-      return;
-    }
+    size - 1,
+  );
+  cursor.offset = start + consumed;
+  for (let i = 0; i < lines.length; i++) {
+    if (i === 0 && isInitialAdd && start > 0) continue;
+    const line = lines[i]!;
     if (line.trim()) onLine(line);
-  });
-  rl.on("close", () => {
-    cursor!.offset = start + consumed;
-  });
+  }
 }
 
 function swallow(err: unknown): void {

--- a/src/util/jsonl-stream.test.ts
+++ b/src/util/jsonl-stream.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  mkdtempSync,
+  writeFileSync,
+  appendFileSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { readNewlineTerminatedLines } from "./jsonl-stream.js";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "jsonl-stream-"));
+}
+
+describe("readNewlineTerminatedLines", () => {
+  it("returns terminated lines and a newline-aligned consumed count", () => {
+    const dir = tmp();
+    const file = join(dir, "x.jsonl");
+    writeFileSync(file, '{"a":1}\n{"b":2}\n');
+    const { lines, consumed } = readNewlineTerminatedLines(file, 0, 15);
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+    expect(consumed).toBe(16);
+  });
+
+  it("drops the trailing partial line and reports consumed up to last \\n", () => {
+    const dir = tmp();
+    const file = join(dir, "x.jsonl");
+    writeFileSync(file, '{"a":1}\n{"b":2'); // no trailing newline
+    const { lines, consumed } = readNewlineTerminatedLines(file, 0, 13);
+    expect(lines).toEqual(['{"a":1}']);
+    // Consumed only counts up to and including the last \n.
+    expect(consumed).toBe(8);
+  });
+
+  it("recovers a previously-partial line after the rest is appended (AUR-227)", () => {
+    const dir = tmp();
+    const file = join(dir, "x.jsonl");
+    // Producer flushes a partial line.
+    writeFileSync(file, '{"id":"a","value":');
+    let stat = statSync(file);
+    const first = readNewlineTerminatedLines(file, 0, stat.size - 1);
+    // No terminated lines yet; nothing consumed.
+    expect(first.lines).toEqual([]);
+    expect(first.consumed).toBe(0);
+
+    // Producer flushes the rest of that line plus the next one.
+    appendFileSync(file, '1}\n{"id":"b","value":2}\n');
+    stat = statSync(file);
+    const second = readNewlineTerminatedLines(
+      file,
+      first.consumed,
+      stat.size - 1,
+    );
+    // The originally-partial line is now recovered intact.
+    expect(second.lines).toEqual([
+      '{"id":"a","value":1}',
+      '{"id":"b","value":2}',
+    ]);
+    expect(first.consumed + second.consumed).toBe(stat.size);
+  });
+
+  it("handles an empty slice", () => {
+    const dir = tmp();
+    const file = join(dir, "x.jsonl");
+    writeFileSync(file, "");
+    const { lines, consumed } = readNewlineTerminatedLines(file, 0, -1);
+    expect(lines).toEqual([]);
+    expect(consumed).toBe(0);
+  });
+
+  it("preserves utf-8 multibyte characters across the newline boundary", () => {
+    const dir = tmp();
+    const file = join(dir, "x.jsonl");
+    writeFileSync(file, '{"x":"héllo"}\n{"y":"日本"}\n');
+    const stat = statSync(file);
+    const { lines, consumed } = readNewlineTerminatedLines(
+      file,
+      0,
+      stat.size - 1,
+    );
+    expect(lines).toEqual(['{"x":"héllo"}', '{"y":"日本"}']);
+    expect(consumed).toBe(stat.size);
+  });
+});

--- a/src/util/jsonl-stream.ts
+++ b/src/util/jsonl-stream.ts
@@ -1,0 +1,46 @@
+import { closeSync, openSync, readSync } from "node:fs";
+
+export interface LineBatch {
+  /** Newline-terminated lines from the slice (newline stripped). The
+   *  trailing partial line, if any, is dropped — caller will re-read it
+   *  on the next iteration once more bytes arrive. */
+  lines: string[];
+  /** Bytes consumed from `start`. Always points at a newline boundary or
+   *  zero. The caller advances their cursor by exactly this amount; any
+   *  unterminated tail stays unread until the next call. */
+  consumed: number;
+}
+
+/** Read [start, end] from `file` synchronously and return only the
+ *  newline-terminated lines plus the byte count of those terminated
+ *  lines. Used by JSONL adapters whose source files can be flushed
+ *  mid-line by their producing process — under the previous readline
+ *  implementation we'd parse the partial line, fail JSON.parse, advance
+ *  past it, and permanently lose the event when the rest of the line was
+ *  later appended. AUR-227. */
+export function readNewlineTerminatedLines(
+  file: string,
+  start: number,
+  end: number,
+): LineBatch {
+  if (end < start) return { lines: [], consumed: 0 };
+  const size = end - start + 1;
+  const buf = Buffer.alloc(size);
+  let read = 0;
+  const fd = openSync(file, "r");
+  try {
+    while (read < size) {
+      const n = readSync(fd, buf, read, size - read, start + read);
+      if (n <= 0) break;
+      read += n;
+    }
+  } finally {
+    closeSync(fd);
+  }
+  const slice = read < size ? buf.subarray(0, read) : buf;
+  const lastNl = slice.lastIndexOf(0x0a);
+  if (lastNl < 0) return { lines: [], consumed: 0 };
+  const terminated = slice.subarray(0, lastNl).toString("utf8");
+  const lines = terminated === "" ? [] : terminated.split("\n");
+  return { lines, consumed: lastNl + 1 };
+}


### PR DESCRIPTION
## Summary

Fixes silent, permanent event loss in the JSONL adapters (claude-code, codex, openclaw) when the producing agent flushes a partial line and our chokidar-driven read fires before the line is newline-terminated.

- New helper \`src/util/jsonl-stream.ts\` returning only \`\n\`-terminated lines and a consumed count aligned to the last newline.
- Refactored all three adapters to advance their cursor by that exact count, so any unterminated tail stays unread until the next pass.
- Removed the \`readline\` + \`createReadStream\` dance the bug lived in.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm test\` — 242 tests pass (was 235; adds 7 new across \`jsonl-stream.test.ts\` and \`claude-code.test.ts\`)
- [x] New tests reproduce the original bug: partial flush → 0 consumed → re-read after rest arrives recovers the full line intact.

Closes AUR-227.