### PR TITLE
feat(adapters): surface unparseable JSONL lines (AUR-228)

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -10,6 +10,7 @@ import { registerSpawn } from "../util/spawn-tracker.js";
 import { costOf, parseUsage } from "../util/cost.js";
 import { markAgentWrite } from "../util/recent-writes.js";
 import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
+import { createParseErrorTracker } from "../util/parse-errors.js";
 
 type Emit = EventSink | ((e: AgentEvent) => void);
 
@@ -44,11 +45,13 @@ interface FileCursor {
 const BACKFILL_BYTES = 4 * 1024 * 1024;
 
 export function startClaudeAdapter(sink: Emit): () => void {
-  const { emit, enrich } = normalizeSink(sink);
+  const normalized = normalizeSink(sink);
+  const { emit, enrich } = normalized;
   const dir = claudeProjectsDir();
   if (!existsSync(dir)) {
     return () => {};
   }
+  const parseErrors = createParseErrorTracker("claude-code", normalized);
 
   const cursors = new Map<string, FileCursor>();
   // chokidar v4 dropped glob support; watch the projects dir recursively
@@ -96,6 +99,7 @@ export function startClaudeAdapter(sink: Emit): () => void {
       try {
         obj = JSON.parse(line);
       } catch {
+        parseErrors.recordFailure(sessionId, line);
         continue;
       }
       // First, harvest any tool_result blocks from user turns — they

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -8,6 +8,7 @@ import { nextId } from "../util/ids.js";
 import { costOf } from "../util/cost.js";
 import { consumeSpawn } from "../util/spawn-tracker.js";
 import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
+import { createParseErrorTracker } from "../util/parse-errors.js";
 
 const BACKFILL_BYTES = 4 * 1024 * 1024;
 
@@ -42,6 +43,7 @@ export function startCodexAdapter(sink: EventSink): () => void {
   const dir = codexSessionsDir();
   if (!existsSync(dir)) return () => {};
 
+  const parseErrors = createParseErrorTracker("codex", sink);
   const cursors = new Map<string, Cursor>();
   const rolloutRe = /rollout-[^/\\]+\.jsonl$/;
   const watcher = chokidar.watch(dir, {
@@ -82,6 +84,7 @@ export function startCodexAdapter(sink: EventSink): () => void {
       try {
         obj = JSON.parse(line) as Record<string, unknown>;
       } catch {
+        parseErrors.recordFailure(sessionId, line);
         continue;
       }
       const payload = (obj.payload ?? {}) as Record<string, unknown>;

--- a/src/adapters/openclaw.ts
+++ b/src/adapters/openclaw.ts
@@ -6,6 +6,7 @@ import type { AgentEvent, EventType } from "../schema.js";
 import { clampTs, riskOf } from "../schema.js";
 import { nextId } from "../util/ids.js";
 import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
+import { createParseErrorTracker } from "../util/parse-errors.js";
 import {
   classifySessionKey,
   type ScheduledMarker,
@@ -67,10 +68,15 @@ export function _resetOpenClawScheduledCache(): void {
 }
 
 export function startOpenClawAdapter(sink: Emit): () => void {
-  const emit = typeof sink === "function" ? sink : sink.emit;
+  const normalized: EventSink =
+    typeof sink === "function"
+      ? { emit: sink, enrich: () => {} }
+      : sink;
+  const emit = normalized.emit;
   const root = join(homedir(), ".openclaw");
   if (!existsSync(root)) return () => {};
 
+  const parseErrors = createParseErrorTracker("openclaw", normalized);
   const cursors = new Map<string, FileCursor>();
   const stoppers: Array<() => void> = [];
 
@@ -86,7 +92,7 @@ export function startOpenClawAdapter(sink: Emit): () => void {
   });
   const handleSession = (f: string, initial: boolean) => {
     if (!sessionRe.test(f)) return;
-    processSession(f, initial, cursors, emit);
+    processSession(f, initial, cursors, emit, parseErrors);
   };
   sessionsWatcher.on("add", (f) => handleSession(f, true));
   sessionsWatcher.on("change", (f) => handleSession(f, false));
@@ -101,8 +107,12 @@ export function startOpenClawAdapter(sink: Emit): () => void {
     persistent: true,
     ignoreInitial: false,
   });
-  auditWatcher.on("add", (f) => processAudit(f, true, cursors, emit));
-  auditWatcher.on("change", (f) => processAudit(f, false, cursors, emit));
+  auditWatcher.on("add", (f) =>
+    processAudit(f, true, cursors, emit, parseErrors),
+  );
+  auditWatcher.on("change", (f) =>
+    processAudit(f, false, cursors, emit, parseErrors),
+  );
   auditWatcher.on("error", swallow);
   stoppers.push(() => {
     void auditWatcher.close();
@@ -118,6 +128,7 @@ function processSession(
   startFromEnd: boolean,
   cursors: Map<string, FileCursor>,
   emit: (e: AgentEvent) => void,
+  parseErrors: { recordFailure(sessionKey: string, line: string): void },
 ) {
   const subAgent = extractSubAgent(file);
   const sessionId = basename(file, ".jsonl");
@@ -130,6 +141,7 @@ function processSession(
     try {
       obj = JSON.parse(line);
     } catch {
+      parseErrors.recordFailure(sessionId, line);
       return;
     }
     const event = translateSession(obj, subAgent, sessionId);
@@ -154,12 +166,14 @@ function processAudit(
   startFromEnd: boolean,
   cursors: Map<string, FileCursor>,
   emit: (e: AgentEvent) => void,
+  parseErrors: { recordFailure(sessionKey: string, line: string): void },
 ) {
   streamLines(file, startFromEnd, cursors, (line) => {
     let obj: unknown;
     try {
       obj = JSON.parse(line);
     } catch {
+      parseErrors.recordFailure("config-audit", line);
       return;
     }
     const event = translateAudit(obj);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -21,6 +21,7 @@ export type EventType =
   | "prompt"
   | "response"
   | "compaction"
+  | "parse_error"
   | "session_start"
   | "session_end";
 
@@ -96,6 +97,12 @@ export interface EventDetails {
      *  (e.g. `cron:<jobId>:run:<runId>`). */
     runId?: string;
   };
+  /** AUR-228: number of unparseable lines we've seen for this session.
+   *  Carried on a synthetic `parse_error` event so operators can see
+   *  they're missing context. */
+  parseErrorCount?: number;
+  /** Truncated preview of the most recent unparseable line. */
+  parseErrorSample?: string;
 }
 
 /** Sink passed to adapters. Adapters emit new events and may later
@@ -148,5 +155,6 @@ export function riskOf(type: EventType, path?: string, cmd?: string): number {
     return 2;
   }
   if (type === "tool_call") return 3;
+  if (type === "parse_error") return 1;
   return 1;
 }

--- a/src/util/parse-errors.test.ts
+++ b/src/util/parse-errors.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent, EventDetails, EventSink } from "../schema.js";
+import { createParseErrorTracker } from "./parse-errors.js";
+
+function makeRecorder(): {
+  sink: EventSink;
+  emitted: AgentEvent[];
+  enrichments: Array<{ id: string; patch: Partial<EventDetails> }>;
+} {
+  const emitted: AgentEvent[] = [];
+  const enrichments: Array<{ id: string; patch: Partial<EventDetails> }> = [];
+  return {
+    sink: {
+      emit: (e) => emitted.push(e),
+      enrich: (id, patch) => enrichments.push({ id, patch }),
+    },
+    emitted,
+    enrichments,
+  };
+}
+
+describe("createParseErrorTracker", () => {
+  it("emits one synthetic parse_error event on the first failure per session", () => {
+    const r = makeRecorder();
+    const tracker = createParseErrorTracker("claude-code", r.sink);
+    tracker.recordFailure("sess-A", "{garbled");
+    expect(r.emitted).toHaveLength(1);
+    expect(r.emitted[0]?.type).toBe("parse_error");
+    expect(r.emitted[0]?.sessionId).toBe("sess-A");
+    expect(r.emitted[0]?.details?.parseErrorCount).toBe(1);
+    expect(r.emitted[0]?.details?.parseErrorSample).toBe("{garbled");
+  });
+
+  it("enriches the existing event on subsequent failures, not emit new ones", () => {
+    const r = makeRecorder();
+    const tracker = createParseErrorTracker("codex", r.sink);
+    tracker.recordFailure("sess-B", "first bad");
+    tracker.recordFailure("sess-B", "second bad");
+    tracker.recordFailure("sess-B", "third bad");
+    expect(r.emitted).toHaveLength(1);
+    expect(r.enrichments).toHaveLength(2);
+    expect(r.enrichments[1]?.patch.parseErrorCount).toBe(3);
+    expect(r.enrichments[1]?.patch.parseErrorSample).toBe("third bad");
+  });
+
+  it("tracks separate counts per session", () => {
+    const r = makeRecorder();
+    const tracker = createParseErrorTracker("openclaw", r.sink);
+    tracker.recordFailure("sess-X", "x1");
+    tracker.recordFailure("sess-Y", "y1");
+    tracker.recordFailure("sess-X", "x2");
+    expect(r.emitted).toHaveLength(2);
+    const sessions = r.emitted.map((e) => e.sessionId).sort();
+    expect(sessions).toEqual(["sess-X", "sess-Y"]);
+    // Y still at 1, X now at 2 (one enrichment).
+    expect(r.enrichments).toHaveLength(1);
+    expect(r.enrichments[0]?.patch.parseErrorCount).toBe(2);
+  });
+
+  it("truncates very long samples to keep the timeline readable", () => {
+    const r = makeRecorder();
+    const tracker = createParseErrorTracker("claude-code", r.sink);
+    const long = "x".repeat(1000);
+    tracker.recordFailure("sess-Z", long);
+    const sample = r.emitted[0]?.details?.parseErrorSample ?? "";
+    expect(sample.length).toBeLessThanOrEqual(200);
+    expect(sample.endsWith("…")).toBe(true);
+  });
+});

--- a/src/util/parse-errors.ts
+++ b/src/util/parse-errors.ts
@@ -1,0 +1,77 @@
+import type { AgentEvent, AgentName, EventSink } from "../schema.js";
+import { riskOf } from "../schema.js";
+import { nextId } from "./ids.js";
+
+/** Per-session running tally of unparseable JSONL lines. AUR-228. The
+ *  tracker emits a single synthetic `parse_error` event the first time
+ *  a session fails to parse a line, and `enrich`es it on every
+ *  subsequent failure with the new count + a truncated sample of the
+ *  offending line. The TUI surfaces this as a session-level warning so
+ *  operators know they're seeing a partial timeline.
+ *
+ *  This sits behind the line-reading layer (jsonl-stream) so the count
+ *  reflects only well-formed lines (newline-terminated) that JSON.parse
+ *  rejected — i.e., genuine schema corruption, not the partial-flush
+ *  case that AUR-227 already handles cleanly. */
+export interface ParseErrorTracker {
+  recordFailure(sessionKey: string, line: string): void;
+}
+
+interface Entry {
+  count: number;
+  eventId?: string;
+}
+
+const SAMPLE_BYTES = 200;
+
+export function createParseErrorTracker(
+  agent: AgentName,
+  sink: EventSink,
+  options: {
+    /** Override summary prefix; defaults to `[<sessionId-prefix>]`. */
+    summaryPrefix?: (sessionKey: string) => string;
+  } = {},
+): ParseErrorTracker {
+  const entries = new Map<string, Entry>();
+  return {
+    recordFailure(sessionKey: string, line: string): void {
+      let entry = entries.get(sessionKey);
+      if (!entry) {
+        entry = { count: 0 };
+        entries.set(sessionKey, entry);
+      }
+      entry.count += 1;
+      const sample = truncate(line, SAMPLE_BYTES);
+
+      if (!entry.eventId) {
+        const prefix =
+          options.summaryPrefix?.(sessionKey) ?? `[${sessionKey.slice(0, 8)}] `;
+        const event: AgentEvent = {
+          id: nextId(),
+          ts: new Date().toISOString(),
+          agent,
+          type: "parse_error",
+          sessionId: sessionKey,
+          riskScore: riskOf("parse_error"),
+          summary: `${prefix}⚠ unparseable line — context loss possible`,
+          details: {
+            parseErrorCount: 1,
+            parseErrorSample: sample,
+          },
+        };
+        entry.eventId = event.id;
+        sink.emit(event);
+      } else {
+        sink.enrich(entry.eventId, {
+          parseErrorCount: entry.count,
+          parseErrorSample: sample,
+        });
+      }
+    },
+  };
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}


### PR DESCRIPTION
## Summary

Stops the JSONL adapters from silently swallowing JSON.parse failures. Operators now see a synthetic timeline marker the first time a session corrupts a line, with a running count + sample of the most recent failure.

- New \`src/util/parse-errors.ts\` — per-session tracker; emits one \`parse_error\` event then enriches it.
- New \`parse_error\` EventType + \`parseErrorCount\` / \`parseErrorSample\` details fields in \`schema.ts\`.
- Wired into claude-code, codex, openclaw (sessions + config-audit JSONL).

> Stacks on PR #8 (AUR-227). Merge that one first or this rebase will pick up its commit too.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm test\` — 246 tests pass (was 242; adds 4 in \`parse-errors.test.ts\`)
- [x] Verify the synthetic event renders at risk 1 (low) with the warning summary.

Closes AUR-228.