### PR TITLE
feat(cost): externalize pricing via ~/.agentwatch/pricing.json (AUR-216)

### DIFF
--- a/docs/features/cost-accounting.md
+++ b/docs/features/cost-accounting.md
@@ -27,11 +27,49 @@ message's `usage` object:
 - `cache_read_input_tokens` (billed at ~10% of input)
 - `output_tokens`
 
-Rate table hardcoded per model in `src/util/cost.ts`:
+Rate table per model lives in `src/util/cost.ts` (DEFAULT_RATES):
 - `claude-opus-4-6`
 - `claude-sonnet-4-6`
 - `claude-haiku-4-5`
+- `gemini-2.5-pro`, `gemini-2.5-flash`
+- `gpt-5`, `gpt-5-mini`
 - `default` fallback (uses sonnet rates)
+
+### Overriding pricing locally (AUR-216)
+
+Provider rates change between releases. Operators can override the
+shipped defaults without rebuilding the CLI by writing a JSON file at
+`~/.agentwatch/pricing.json` (or wherever `AGENTWATCH_PRICING_PATH`
+points):
+
+```json
+{
+  "claude-opus-4-6": {
+    "input": 15.0,
+    "cacheCreate": 18.75,
+    "cacheRead": 1.5,
+    "output": 75.0
+  },
+  "my-local-model": {
+    "input": 0,
+    "cacheCreate": 0,
+    "cacheRead": 0,
+    "output": 0
+  }
+}
+```
+
+Rules:
+- Keys are the **normalized** model name (e.g. `gpt-5` not `gpt-5.4-preview`;
+  see `normalizeModel` in `cost.ts`).
+- Values are USD per **million** tokens.
+- All four fields (`input`, `cacheCreate`, `cacheRead`, `output`) must be
+  non-negative numbers — partial entries are dropped (we never silently
+  use a stale field).
+- Unknown / missing models fall back to `default` from `DEFAULT_RATES`.
+- The file is read once at adapter startup. Restart agentwatch to pick
+  up edits.
+- Set `AGENTWATCH_PRICING_DEBUG=1` to log validation rejections.
 
 `costOf(model, usage)` returns USD as a float. `formatUSD(n)` formats with
 adaptive precision:

--- a/src/util/cost.test.ts
+++ b/src/util/cost.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  _resetPricingCache,
+  costOf,
+  formatUSD,
+  loadRates,
+  parseUsage,
+} from "./cost.js";
+
+const ENV = "AGENTWATCH_PRICING_PATH";
+const DEBUG_ENV = "AGENTWATCH_PRICING_DEBUG";
+
+function withPricingFile(json: object): string {
+  const dir = mkdtempSync(join(tmpdir(), "aw-pricing-"));
+  const path = join(dir, "pricing.json");
+  writeFileSync(path, JSON.stringify(json));
+  return path;
+}
+
+describe("costOf + loadRates", () => {
+  const original = process.env[ENV];
+
+  beforeEach(() => {
+    _resetPricingCache();
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV];
+    else process.env[ENV] = original;
+    delete process.env[DEBUG_ENV];
+    _resetPricingCache();
+  });
+
+  it("falls back to baked-in defaults when no pricing file exists", () => {
+    process.env[ENV] = "/nonexistent/agentwatch-pricing.json";
+    const cost = costOf("claude-sonnet-4-6", {
+      input: 1_000_000,
+      cacheCreate: 0,
+      cacheRead: 0,
+      output: 0,
+    });
+    expect(cost).toBeCloseTo(3.0, 5);
+  });
+
+  it("AUR-216: an entry in the user pricing file overrides the default for that model", () => {
+    process.env[ENV] = withPricingFile({
+      "claude-sonnet-4-6": {
+        input: 999.0,
+        cacheCreate: 0,
+        cacheRead: 0,
+        output: 0,
+      },
+    });
+    const cost = costOf("claude-sonnet-4-6", {
+      input: 1_000_000,
+      cacheCreate: 0,
+      cacheRead: 0,
+      output: 0,
+    });
+    expect(cost).toBeCloseTo(999.0, 5);
+  });
+
+  it("preserves defaults for models the user file does not mention", () => {
+    process.env[ENV] = withPricingFile({
+      "my-experimental": {
+        input: 0,
+        cacheCreate: 0,
+        cacheRead: 0,
+        output: 0,
+      },
+    });
+    // claude-sonnet-4-6 was not overridden — still $3/M input.
+    const cost = costOf("claude-sonnet-4-6", {
+      input: 1_000_000,
+      cacheCreate: 0,
+      cacheRead: 0,
+      output: 0,
+    });
+    expect(cost).toBeCloseTo(3.0, 5);
+    // The new model is now priced (and cheap).
+    const c2 = costOf("my-experimental", {
+      input: 5_000_000,
+      cacheCreate: 0,
+      cacheRead: 0,
+      output: 0,
+    });
+    expect(c2).toBe(0);
+  });
+
+  it("drops invalid entries (missing field, negative, wrong type)", () => {
+    process.env[ENV] = withPricingFile({
+      "claude-opus-4-6": {
+        input: -1,
+        cacheCreate: 0,
+        cacheRead: 0,
+        output: 0,
+      },
+      "claude-sonnet-4-6": {
+        input: 5,
+        cacheCreate: 0,
+        cacheRead: 0,
+        // missing output
+      },
+      "claude-haiku-4-5": "not-an-object",
+    });
+    const rates = loadRates();
+    // Defaults survived because all three overrides were rejected.
+    expect(rates["claude-opus-4-6"]?.input).toBe(15.0);
+    expect(rates["claude-sonnet-4-6"]?.input).toBe(3.0);
+    expect(rates["claude-haiku-4-5"]?.input).toBe(1.0);
+  });
+
+  it("normalizes model variants (gpt-5.4 → gpt-5, gemini-2.5-pro-preview → gemini-2.5-pro)", () => {
+    const a = costOf("gpt-5.4-preview", {
+      input: 1_000_000,
+      cacheCreate: 0,
+      cacheRead: 0,
+      output: 0,
+    });
+    const b = costOf("gpt-5", {
+      input: 1_000_000,
+      cacheCreate: 0,
+      cacheRead: 0,
+      output: 0,
+    });
+    expect(a).toBeCloseTo(b, 5);
+  });
+
+  it("falls back to default rates for unknown models", () => {
+    const cost = costOf("totally-unknown-model", {
+      input: 1_000_000,
+      cacheCreate: 0,
+      cacheRead: 0,
+      output: 0,
+    });
+    // default.input is 3.0 (sonnet-equivalent fallback).
+    expect(cost).toBeCloseTo(3.0, 5);
+  });
+});
+
+describe("formatUSD", () => {
+  it("uses adaptive precision based on magnitude", () => {
+    expect(formatUSD(0)).toBe("$0");
+    expect(formatUSD(0.001)).toBe("$0.0010");
+    expect(formatUSD(0.5)).toBe("$0.500");
+    expect(formatUSD(12.4)).toBe("$12.40");
+  });
+});
+
+describe("parseUsage", () => {
+  it("returns the four-field object when all keys are present", () => {
+    const u = parseUsage({
+      input_tokens: 10,
+      cache_creation_input_tokens: 5,
+      cache_read_input_tokens: 100,
+      output_tokens: 50,
+    });
+    expect(u).toEqual({
+      input: 10,
+      cacheCreate: 5,
+      cacheRead: 100,
+      output: 50,
+    });
+  });
+
+  it("returns null when nothing useful is present", () => {
+    expect(parseUsage(null)).toBeNull();
+    expect(parseUsage({})).toBeNull();
+    expect(
+      parseUsage({
+        input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 0,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/util/cost.ts
+++ b/src/util/cost.ts
@@ -1,5 +1,25 @@
-/** Per-million-token rates in USD. Update when Anthropic changes pricing. */
-const RATES: Record<
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Per-million-token rates in USD. AUR-216: defaults below ship with
+ *  the CLI, but operators can override or add new models by writing a
+ *  JSON file at `~/.agentwatch/pricing.json` (or wherever the env var
+ *  AGENTWATCH_PRICING_PATH points). The file is shape:
+ *
+ *    {
+ *      "claude-opus-4-6":  { "input": 15.0, "cacheCreate": 18.75, ... },
+ *      "gpt-5":            { "input": 1.5,  "output":      11.0,  ... },
+ *      "my-local-model":   { "input": 0,    "output":      0      }
+ *    }
+ *
+ *  The model key is the normalized name (see normalizeModel below).
+ *  The user file is shallow-merged into the defaults — any model
+ *  present in the user file wins for that whole entry; other defaults
+ *  are preserved. Partial overrides at the field level are NOT
+ *  supported (it's all four numbers, or nothing) so we never silently
+ *  use a stale field if the operator only wrote `input`. */
+const DEFAULT_RATES: Record<
   string,
   {
     input: number;
@@ -61,6 +81,81 @@ const RATES: Record<
   },
 };
 
+export type Rate = (typeof DEFAULT_RATES)[string];
+
+let cachedRates: Record<string, Rate> | null = null;
+
+export function pricingFilePath(): string {
+  return (
+    process.env.AGENTWATCH_PRICING_PATH ??
+    join(homedir(), ".agentwatch", "pricing.json")
+  );
+}
+
+/** Validate a single rate entry — every field must be a non-negative
+ *  number. Returns null for invalid shapes so the caller can keep the
+ *  default for that model. */
+function coerceRate(v: unknown): Rate | null {
+  if (!v || typeof v !== "object") return null;
+  const r = v as Record<string, unknown>;
+  const isNonNegNumber = (x: unknown): x is number =>
+    typeof x === "number" && Number.isFinite(x) && x >= 0;
+  if (
+    !isNonNegNumber(r.input) ||
+    !isNonNegNumber(r.cacheCreate) ||
+    !isNonNegNumber(r.cacheRead) ||
+    !isNonNegNumber(r.output)
+  ) {
+    return null;
+  }
+  return {
+    input: r.input,
+    cacheCreate: r.cacheCreate,
+    cacheRead: r.cacheRead,
+    output: r.output,
+  };
+}
+
+export function loadRates(): Record<string, Rate> {
+  if (cachedRates) return cachedRates;
+  const path = pricingFilePath();
+  const merged: Record<string, Rate> = { ...DEFAULT_RATES };
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, "utf8");
+      const doc = JSON.parse(raw);
+      if (doc && typeof doc === "object") {
+        for (const [model, value] of Object.entries(
+          doc as Record<string, unknown>,
+        )) {
+          const rate = coerceRate(value);
+          if (rate) merged[model] = rate;
+          else if (process.env.AGENTWATCH_PRICING_DEBUG) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `[agentwatch/cost] dropping invalid pricing entry for "${model}" — needs input/cacheCreate/cacheRead/output non-negative numbers`,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[agentwatch/cost] failed to read ${path}: ${String(err)}; using built-in defaults`,
+      );
+    }
+  }
+  cachedRates = merged;
+  return merged;
+}
+
+/** @internal Test-only: drop the cached rates so the next loadRates()
+ *  call re-reads the file. Lets tests point AGENTWATCH_PRICING_PATH at
+ *  a fixture and observe the override. */
+export function _resetPricingCache(): void {
+  cachedRates = null;
+}
+
 export interface Usage {
   input: number;
   cacheCreate: number;
@@ -70,7 +165,8 @@ export interface Usage {
 
 /** Returns USD cost for a single message's usage object. */
 export function costOf(model: string, u: Usage): number {
-  const rate = RATES[normalizeModel(model)] ?? RATES.default!;
+  const rates = loadRates();
+  const rate = rates[normalizeModel(model)] ?? rates.default!;
   return (
     (u.input * rate.input +
       u.cacheCreate * rate.cacheCreate +


### PR DESCRIPTION
## Summary

Provider rates drift between agentwatch releases. Until now they were hardcoded in \`src/util/cost.ts\`, so any provider price change silently produced wrong cost math for every operator until a new CLI version shipped.

- New \`loadRates()\` merges baked-in defaults with overrides from \`~/.agentwatch/pricing.json\` (or wherever \`AGENTWATCH_PRICING_PATH\` points).
- Each override must carry all four fields (\`input\`, \`cacheCreate\`, \`cacheRead\`, \`output\`) as non-negative numbers — partial entries are rejected so we never mix stale + fresh values silently. Set \`AGENTWATCH_PRICING_DEBUG=1\` to log rejections.
- Schema and rules documented in \`docs/features/cost-accounting.md\`.
- File is read once at startup; restart the CLI to pick up edits.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm test\` — 244 tests pass (was 235; adds 9 in \`cost.test.ts\` for default fallback, override, partial-rejection, model normalization, and edge cases).
- [x] Smoke test: write a pricing.json overriding sonnet to \$999/M, observe \`costOf\` returning \$999 for 1M input tokens.

Closes AUR-216.