### PR TITLE
fix(directives): defensive initializer for last-triage.txt (AUR-242)

### DIFF
--- a/.agentwatch-bot/prompt.md
+++ b/.agentwatch-bot/prompt.md
@@ -146,6 +146,11 @@ prefix and the reason.
 7. Execute the mode end-to-end.
 8. Telegram-ping with summary + URL.
 
+> **TRIAGE quirk (AUR-242):** if you pick TRIAGE mode, run the
+> last-triage initializer block from AGENT_DIRECTIVES.md §5 *before*
+> running any gh search. The file may be missing or garbled on a fresh
+> machine and that breaks the query silently.
+
 ---
 
 ## Rules that apply *always*

--- a/AGENT_DIRECTIVES.md
+++ b/AGENT_DIRECTIVES.md
@@ -175,8 +175,32 @@ The repo is public on GitHub. External people open issues and PRs.
 Your job in this mode is to **route, label, and draft responses — never
 to speak for the maintainer or merge anything**.
 
-Activity to scan each run (since the last triage timestamp in
-`~/.agentwatch-bot/last-triage.txt` — create it on first run with `now`):
+Activity to scan each run, since the last triage timestamp in
+`~/.agentwatch-bot/last-triage.txt`. **AUR-242: this file may be missing,
+empty, or garbled — initialize defensively before reading.** Run
+exactly this block at the start of TRIAGE mode:
+
+```bash
+TRIAGE_FILE=~/.agentwatch-bot/last-triage.txt
+mkdir -p "$(dirname "$TRIAGE_FILE")"
+# Default to now-24h so the first run still surfaces recent activity
+# instead of an empty scan.
+DEFAULT_TRIAGE=$(date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+if [ ! -f "$TRIAGE_FILE" ]; then
+  echo "$DEFAULT_TRIAGE" > "$TRIAGE_FILE"
+fi
+LAST_TRIAGE_ISO=$(cat "$TRIAGE_FILE")
+# Reject anything that doesn't look like an ISO-8601 UTC timestamp.
+if ! echo "$LAST_TRIAGE_ISO" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'; then
+  LAST_TRIAGE_ISO="$DEFAULT_TRIAGE"
+  echo "$LAST_TRIAGE_ISO" > "$TRIAGE_FILE"
+fi
+LAST_TRIAGE=${LAST_TRIAGE_ISO%Z}  # `gh search` wants no trailing Z
+```
+
+This makes the gh search query stable on a fresh dev machine, after a
+manual edit, or if the file is wiped between runs.
 
 - **New issues:** `gh issue list --state open --search "created:>$LAST_TRIAGE sort:created-desc"`
 - **New PRs:** `gh pr list --state open --search "created:>$LAST_TRIAGE"`


### PR DESCRIPTION
## Summary

The TRIAGE mode in \`AGENT_DIRECTIVES.md\` §5 referenced \`~/.agentwatch-bot/last-triage.txt\` with the vague hint *"create it on first run with \`now\`"*. On a fresh dev machine, after a manual edit, or whenever the file gets wiped, the \`gh search \"created:>\$LAST_TRIAGE\"\` query silently broke and the bot triaged nothing.

Replaced the parenthetical with an explicit bash block that:

- \`mkdir -p\` the dotdir.
- Writes a *now − 24h* ISO timestamp if the file is missing (so the first run still surfaces recent activity instead of an empty scan).
- Validates the file content matches \`^YYYY-MM-DDTHH:MM:SSZ\$\`. Rewrites the default if not.
- Splits the trailing \`Z\` for the gh search variant that wants \`created:>...\` without it.

Also added a TRIAGE quirk reminder in \`.agentwatch-bot/prompt.md\` so the bot runs the initializer before its first gh search.

## Test plan

- [x] Reviewed the new block on macOS (BSD \`date -v-24H\`) and Linux (\`date -d '24 hours ago'\`) — the \`||\` fallback handles both.
- [x] Pattern grep validates the ISO-8601 UTC shape (rejects empty file, garbled file, or a stray newline).

Closes AUR-242.