### PR TITLE
release: v0.0.5 — robustness wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+## [0.0.5] — 2026-05-01
+
+### Added
+- **Externalized pricing** via `~/.agentwatch/pricing.json` (AUR-216) — per-model
+  rates can be overridden without rebuilding the binary; the in-tree defaults
+  are loaded as a fallback when the file is absent.
+- **OpenClaw `toolResult` pairing** (AUR-217) — toolResult turns now back-fill
+  the originating toolCall with output, duration, and error flag, matching
+  Claude/Codex parity.
+- **Unparseable JSONL lines surfaced** as a structured `parse_error` event
+  (AUR-228) instead of being silently swallowed; you now see when an adapter
+  is choking on malformed input.
+
+### Fixed
+- **Partial JSONL lines preserved across reads** (AUR-227) — a chunk boundary
+  in the middle of a line no longer truncates the event; tail buffer holds
+  the partial line until the newline arrives.
+- **Version no longer drifts between `package.json` and runtime** — `--version`
+  reads `package.json` instead of a hardcoded constant.
+- **`bin/agentwatch.js` is executable** in the published tarball
+  (a `chmod +x` was missing from the build).
+
+### Docs
+- Documented that Gemini CLI and OpenClaw do not persist compaction markers
+  to disk (AUR-214) — this is a structural limit of what those agents write,
+  not a missing adapter feature.
+
+### Internal
+- AGENT_DIRECTIVES.md hardening for the autonomous agentwatch-bot harness
+  (AUR-241 timeout wrappers, AUR-242 defensive `last-triage.txt` initializer).
+  These are agent-harness changes only; no user-facing impact.
+
 ## [0.0.3] — 2026-04-15
 
 ### Added — full multi-agent + moats wave

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misha_misha/agentwatch",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Local-only observability + control plane for every AI coding agent on your machine. TUI live tail + browser dashboard on localhost. Unified timeline across Claude Code, Codex, Gemini CLI, Cursor, Hermes, OpenClaw — token + cost accounting, compaction + anomaly detection, SVG call graphs, diff attribution, agent-aware replay, MCP server mode, OpenTelemetry exporter. No cloud, no telemetry, no sign-in.",
   "type": "module",
   "author": "Misha Nefedov",


### PR DESCRIPTION
## Summary

- Bumps `package.json` to **0.0.5**.
- Moves the eight unreleased fixes since the v0.0.4 tag into a new `[0.0.5] — 2026-05-01` CHANGELOG section, grouped Added / Fixed / Docs / Internal:
  - AUR-216 externalized pricing via `~/.agentwatch/pricing.json`
  - AUR-217 OpenClaw toolResult→toolCall pairing
  - AUR-228 surface unparseable JSONL lines
  - AUR-227 preserve partial JSONL across reads
  - AUR-214 docs on Gemini/OpenClaw compaction structural limit
  - AUR-241 / AUR-242 directives hardening (agent-only)
  - version-from-package.json + chmod on bin
- No new features. Pure release-hygiene cut to clear the deck before v0.1 work.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 262/262 pass
- [x] `npm run build` succeeds
- [ ] After merge: `npm publish` (requires maintainer's npm credentials — flagged as a manual step in the Linear ticket)

Closes [AUR-261](https://linear.app/auraqu/issue/AUR-261/v005-cleanup-release-version-changelog-npm-publish).