### PR TITLE
feat(store): SQLite event store with FTS5 (AUR-263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ layout can change freely within a minor version.
   hits the FTS5 index for full-history matches (vs the live ring buffer
   or the JSONL cross-scan). Returns FTS-ranked snippets.
 
+- **Background daemon** (AUR-262) — `agentwatch daemon start | stop |
+  status | logs` installs a launchd LaunchAgent (macOS) or a systemd
+  user unit (Linux) that runs the adapter pipeline 24/7, writing every
+  event into `~/.agentwatch/events.db`. The TUI and `agentwatch serve`
+  are now read clients of the same store, so events captured overnight
+  are visible the moment you open them. PID file + start-time at
+  `~/.agentwatch/daemon.{pid,started_at}`; log at
+  `~/.agentwatch/daemon.log` with a 10 MB single-slot rotation; PID
+  re-acquire is stale-PID-aware (process-alive probe).
+
 ### Changed
 
 - **EventSink wired through the store** in both TUI and `serve` modes —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+### Added — v0.1 foundation
+
+- **SQLite event store** (AUR-263) at `~/.agentwatch/events.db` — replaces
+  the 4 MB rolling backfill with a persistent indexed store. WAL mode
+  + `synchronous=NORMAL` + FTS5 virtual table over prompt/response/
+  thinking/tool_result/summary. Migrations are versioned (`schema_version`
+  table). Three tables: `events` (canonical AgentEvent), `sessions`
+  (auto-aggregated via trigger on event insert: cost, ts range, count,
+  project), `tool_calls` (tool, duration, error). Bench: ingests 10k
+  events in ~430ms on M1 air.
+- **`agentwatch prune --older-than-days N`** — drops events older than
+  the cutoff (default 90 days), VACUUMs the DB on non-trivial prunes,
+  prints the resulting size.
+- **Search history mode** — `POST /api/search` with `mode: "history"`
+  hits the FTS5 index for full-history matches (vs the live ring buffer
+  or the JSONL cross-scan). Returns FTS-ranked snippets.
+
+### Changed
+
+- **EventSink wired through the store** in both TUI and `serve` modes —
+  every emit/enrich is now mirrored to SQLite. Failures are logged once
+  and never propagated; the in-memory pipeline remains the source of
+  truth for the live SSE stream.
+
 ## [0.0.3] — 2026-04-15
 
 ### Added — full multi-agent + moats wave

--- a/src/classify/activity.test.ts
+++ b/src/classify/activity.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../schema.js";
+import {
+  ACTIVITY_CATEGORIES,
+  classifyEvent,
+  type ActivityCategory,
+} from "./activity.js";
+import { withClassifier } from "./sink.js";
+
+let id = 0;
+
+function evt(over: Partial<AgentEvent>): AgentEvent {
+  return {
+    id: `e-${++id}`,
+    ts: new Date().toISOString(),
+    agent: over.agent ?? "claude-code",
+    type: over.type ?? "tool_call",
+    riskScore: over.riskScore ?? 1,
+    path: over.path,
+    cmd: over.cmd,
+    tool: over.tool,
+    summary: over.summary,
+    sessionId: over.sessionId,
+    promptId: over.promptId,
+    details: over.details,
+  };
+}
+
+interface Case {
+  name: string;
+  expect: ActivityCategory;
+  event: AgentEvent;
+}
+
+const CASES: Case[] = [
+  // ---- coding ----
+  {
+    name: "writing a TypeScript source file",
+    expect: "coding",
+    event: evt({ type: "file_write", path: "src/api/auth.ts", tool: "Write" }),
+  },
+  {
+    name: "editing a Python source file",
+    expect: "coding",
+    event: evt({ type: "file_change", path: "app/handlers/login.py" }),
+  },
+  {
+    name: "MultiEdit on a Go file",
+    expect: "coding",
+    event: evt({ type: "file_write", path: "internal/server/routes.go", tool: "MultiEdit" }),
+  },
+  {
+    name: "git commit shell exec",
+    expect: "coding",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "git commit -m feat: add login" }),
+  },
+
+  // ---- testing ----
+  {
+    name: "writing a vitest test file",
+    expect: "testing",
+    event: evt({ type: "file_write", path: "src/api/auth.test.ts", tool: "Write" }),
+  },
+  {
+    name: "writing a pytest test under tests/",
+    expect: "testing",
+    event: evt({ type: "file_write", path: "tests/test_login.py" }),
+  },
+  {
+    name: "running npm test",
+    expect: "testing",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "npm test" }),
+  },
+  {
+    name: "running pytest",
+    expect: "testing",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "pytest -k login" }),
+  },
+
+  // ---- docs ----
+  {
+    name: "editing a markdown doc",
+    expect: "docs",
+    event: evt({ type: "file_write", path: "docs/features/api.md" }),
+  },
+  {
+    name: "editing the README",
+    expect: "docs",
+    event: evt({ type: "file_write", path: "README.md" }),
+  },
+  {
+    name: "editing CHANGELOG",
+    expect: "docs",
+    event: evt({ type: "file_write", path: "CHANGELOG.md" }),
+  },
+
+  // ---- config ----
+  {
+    name: "editing tsconfig.json",
+    expect: "config",
+    event: evt({ type: "file_write", path: "tsconfig.json" }),
+  },
+  {
+    name: "editing a yaml config",
+    expect: "config",
+    event: evt({ type: "file_write", path: "k8s/deployment.yaml" }),
+  },
+  {
+    name: "editing package.json",
+    expect: "config",
+    event: evt({ type: "file_write", path: "package.json" }),
+  },
+
+  // ---- debugging ----
+  {
+    name: "prompt mentioning a stack trace",
+    expect: "debugging",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "I'm getting a stack trace when I call /login — can you fix this bug?" },
+    }),
+  },
+  {
+    name: "shell exec with tool error",
+    expect: "debugging",
+    event: evt({
+      type: "shell_exec",
+      tool: "Bash",
+      cmd: "npm run build",
+      details: { toolError: true },
+    }),
+  },
+
+  // ---- refactor ----
+  {
+    name: "prompt asking to refactor",
+    expect: "refactor",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "please refactor this file to extract the validation logic into its own module" },
+    }),
+  },
+  {
+    name: "prompt asking to rename",
+    expect: "refactor",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "rename getUser to fetchUserById and move it to api/user.ts" },
+    }),
+  },
+
+  // ---- exploration ----
+  {
+    name: "Grep tool call",
+    expect: "exploration",
+    event: evt({ type: "tool_call", tool: "Grep" }),
+  },
+  {
+    name: "reading a non-config source file",
+    expect: "exploration",
+    event: evt({ type: "file_read", path: "src/util/cost.ts" }),
+  },
+
+  // ---- research ----
+  {
+    name: "WebFetch tool call",
+    expect: "research",
+    event: evt({ type: "tool_call", tool: "WebFetch" }),
+  },
+  {
+    name: "WebSearch tool call",
+    expect: "research",
+    event: evt({ type: "tool_call", tool: "WebSearch" }),
+  },
+
+  // ---- review ----
+  {
+    name: "git diff shell exec",
+    expect: "review",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "git diff main" }),
+  },
+  {
+    name: "prompt asking to audit",
+    expect: "review",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "please audit this file for SQL injection vulnerabilities" },
+    }),
+  },
+
+  // ---- devops ----
+  {
+    name: "kubectl shell exec",
+    expect: "devops",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "kubectl get pods -n prod" }),
+  },
+  {
+    name: "docker shell exec",
+    expect: "devops",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "docker compose up -d" }),
+  },
+  {
+    name: "terraform shell exec",
+    expect: "devops",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "terraform apply" }),
+  },
+
+  // ---- planning ----
+  {
+    name: "long thinking block",
+    expect: "planning",
+    event: evt({
+      type: "response",
+      details: {
+        thinking: "Let me think through this carefully. ".repeat(80),
+      },
+    }),
+  },
+  {
+    name: "compaction event",
+    expect: "planning",
+    event: evt({ type: "compaction" }),
+  },
+
+  // ---- chat ----
+  {
+    name: "session_start",
+    expect: "chat",
+    event: evt({ type: "session_start" }),
+  },
+  {
+    name: "empty assistant turn",
+    expect: "chat",
+    event: evt({
+      type: "response",
+      details: { fullText: "Sure, here you go." },
+    }),
+  },
+];
+
+describe("classifier — synthetic case dataset", () => {
+  for (const c of CASES) {
+    it(c.name, () => {
+      expect(classifyEvent(c.event)).toBe(c.expect);
+    });
+  }
+
+  it("hits at least 75% top-1 agreement on the synthetic dataset", () => {
+    let matches = 0;
+    for (const c of CASES) {
+      if (classifyEvent(c.event) === c.expect) matches += 1;
+    }
+    const ratio = matches / CASES.length;
+    expect(ratio).toBeGreaterThanOrEqual(0.75);
+  });
+
+  it("returns one of the declared categories for any non-empty input", () => {
+    const valid = new Set<string>(ACTIVITY_CATEGORIES);
+    for (const c of CASES) {
+      expect(valid.has(classifyEvent(c.event))).toBe(true);
+    }
+  });
+});
+
+describe("classifier — withClassifier sink wrapper", () => {
+  it("attaches details.category to events that don't already have one", () => {
+    const captured: AgentEvent[] = [];
+    const inner = {
+      emit: (e: AgentEvent) => captured.push(e),
+      enrich: () => undefined,
+    };
+    const wrapped = withClassifier(inner);
+    wrapped.emit(
+      evt({ type: "file_write", path: "src/api.ts", tool: "Write" }),
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.details?.category).toBe("coding");
+  });
+
+  it("doesn't overwrite a category an upstream sink already set", () => {
+    const captured: AgentEvent[] = [];
+    const inner = {
+      emit: (e: AgentEvent) => captured.push(e),
+      enrich: () => undefined,
+    };
+    const wrapped = withClassifier(inner);
+    wrapped.emit(
+      evt({
+        type: "file_write",
+        path: "src/api.ts",
+        details: { category: "review" },
+      }),
+    );
+    expect(captured[0]?.details?.category).toBe("review");
+  });
+
+  it("forwards enrich unchanged", () => {
+    const enriches: Array<{ id: string; patch: object }> = [];
+    const inner = {
+      emit: () => undefined,
+      enrich: (id: string, patch: object) => enriches.push({ id, patch }),
+    };
+    const wrapped = withClassifier(inner);
+    wrapped.enrich("e-1", { toolResult: "ok" });
+    expect(enriches).toEqual([{ id: "e-1", patch: { toolResult: "ok" } }]);
+  });
+});

--- a/src/classify/activity.ts
+++ b/src/classify/activity.ts
@@ -1,0 +1,196 @@
+import type { AgentEvent } from "../schema.js";
+
+export type ActivityCategory =
+  | "coding"
+  | "debugging"
+  | "exploration"
+  | "planning"
+  | "refactor"
+  | "testing"
+  | "docs"
+  | "chat"
+  | "config"
+  | "review"
+  | "devops"
+  | "research";
+
+export const ACTIVITY_CATEGORIES: ActivityCategory[] = [
+  "coding",
+  "debugging",
+  "exploration",
+  "planning",
+  "refactor",
+  "testing",
+  "docs",
+  "chat",
+  "config",
+  "review",
+  "devops",
+  "research",
+];
+
+/** Classify a single event into one of the activity categories.
+ *
+ *  This is a heuristic ladder: each rule contributes a weighted score
+ *  for one category, and the highest-scoring category wins. The
+ *  categories are deliberately broad (matching CodeBurn's 13 buckets)
+ *  so the resulting pie chart answers "where is my spend going?" not
+ *  "what exact thing is the agent doing?"
+ *
+ *  Heuristics are derived from observable signals only — tool name,
+ *  file extension, command verb, and a small keyword set on prompt /
+ *  response text. No ML dependency. When no rule fires we fall through
+ *  to `chat` (the catch-all bucket for assistant turns with no tool use). */
+export function classifyEvent(event: AgentEvent): ActivityCategory {
+  const scores = scoreEvent(event);
+  let winner: ActivityCategory = "chat";
+  let max = 0;
+  for (const cat of ACTIVITY_CATEGORIES) {
+    const s = scores[cat] ?? 0;
+    if (s > max) {
+      max = s;
+      winner = cat;
+    }
+  }
+  return winner;
+}
+
+export function scoreEvent(
+  event: AgentEvent,
+): Partial<Record<ActivityCategory, number>> {
+  const scores: Partial<Record<ActivityCategory, number>> = {};
+  const add = (cat: ActivityCategory, n: number): void => {
+    scores[cat] = (scores[cat] ?? 0) + n;
+  };
+
+  const path = (event.path ?? "").toLowerCase();
+  const cmd = (event.cmd ?? "").toLowerCase();
+  const tool = (event.tool ?? "").toLowerCase();
+  const summary = (event.summary ?? "").toLowerCase();
+  const fullText = (event.details?.fullText ?? "").toLowerCase();
+  const thinking = (event.details?.thinking ?? "").toLowerCase();
+  const toolError = event.details?.toolError === true;
+  const text = `${summary} ${fullText} ${thinking}`;
+
+  // ---- File-extension signals ----
+  if (event.type === "file_write" || event.type === "file_change") {
+    if (isTestPath(path)) add("testing", 8);
+    else if (isDocPath(path)) add("docs", 8);
+    else if (isConfigPath(path)) add("config", 8);
+    else add("coding", 7);
+  } else if (event.type === "file_read") {
+    if (isTestPath(path)) add("testing", 3);
+    else if (isDocPath(path)) add("docs", 3);
+    else if (isConfigPath(path)) add("config", 3);
+    else add("exploration", 4);
+  }
+
+  // ---- Tool signals ----
+  if (tool === "edit" || tool === "multiedit" || tool === "write") {
+    if (isTestPath(path)) add("testing", 4);
+    else if (isDocPath(path)) add("docs", 4);
+    else add("coding", 4);
+  }
+  if (tool === "read") add("exploration", 1);
+  if (tool === "grep" || tool === "glob") add("exploration", 3);
+  if (tool === "webfetch" || tool === "websearch") add("research", 6);
+  if (tool === "task") add("planning", 2);
+
+  // ---- Shell-command signals ----
+  if (event.type === "shell_exec" || tool === "bash") {
+    if (/(\bnpm test\b|\bvitest\b|\bjest\b|\bpytest\b|\bmocha\b|\bpnpm test\b|\bcargo test\b|\bgo test\b)/.test(cmd)) {
+      add("testing", 8);
+    }
+    if (/(\bdocker\b|\bkubectl\b|\bterraform\b|\bansible\b|\bhelm\b|\baws\b|\bgcloud\b|\bsystemctl\b)/.test(cmd)) {
+      add("devops", 7);
+    }
+    if (/\bgit\s+(diff|status|log|blame|show)/.test(cmd)) add("review", 4);
+    if (/\bgit\s+(add|commit|push|merge|rebase|checkout)/.test(cmd)) add("coding", 3);
+    if (/\b(eslint|prettier|tsc|typecheck|lint|mypy|pyright)\b/.test(cmd)) add("review", 3);
+    if (/\b(make|cargo|npm run|pnpm run|yarn run|bun run)\b/.test(cmd)) add("coding", 2);
+    if (toolError) add("debugging", 4);
+  }
+
+  // ---- Text signals (prompt + response + thinking content) ----
+  if (event.type === "prompt" || event.type === "response") {
+    if (/\b(refactor|rename|extract|inline|move|reorganize|restructure)\b/.test(text)) {
+      add("refactor", 6);
+    }
+    if (/\b(error|exception|stack[- ]?trace|traceback|fail(?:ed|ing|ure)?|broken|bug|crash|throws?|undefined is not|cannot read prop|nullpointer)\b/.test(text)) {
+      add("debugging", 5);
+    }
+    if (/\b(test(?:s|ing)?|assert(?:ion)?s?|spec(?:s|tests)?|coverage|mock(?:s|ing)?)\b/.test(text)) {
+      add("testing", 3);
+    }
+    if (/\b(review|audit|check|look at|inspect|verify|critique)\b/.test(text)) {
+      add("review", 4);
+    }
+    if (/\b(plan|approach|step\s\d|first[, ]|then\b|finally\b|let\s+me\s+think|let\s+us|design)\b/.test(text)) {
+      add("planning", 2);
+    }
+    if (/\b(deploy|deployment|release|rollout|pipeline|ci\/cd|production|staging|prod\b)\b/.test(text)) {
+      add("devops", 3);
+    }
+    if (/\b(document(?:ation)?|readme|changelog|docs?\b|comment[s]?|jsdoc|tsdoc|docstring)\b/.test(text)) {
+      add("docs", 3);
+    }
+    if (/\b(config(?:ure|uration)?|settings|environment|env\s+var|toml|yaml|yml|tsconfig|package\.json)\b/.test(text)) {
+      add("config", 3);
+    }
+    if (/\b(research|read about|articles?|paper(s)?|blog\b|reference|literature)\b/.test(text)) {
+      add("research", 3);
+    }
+    if (/\b(what is|how does|how do i|where is|find\b|search\b|locate\b)\b/.test(text)) {
+      add("exploration", 2);
+    }
+  }
+
+  // ---- Thinking-block weight: long thinking dominates planning ----
+  const thinkingLen = thinking.length;
+  if (thinkingLen > 1500) add("planning", 5);
+  else if (thinkingLen > 300) add("planning", 2);
+
+  // ---- Catch-all so chat wins for empty assistant chatter ----
+  if (event.type === "prompt" || event.type === "response") {
+    if (Object.keys(scores).length === 0) add("chat", 1);
+  }
+
+  // Session-scaffolding events shouldn't bias category weight; classify
+  // them as chat by convention so they don't poison the pie chart.
+  if (event.type === "session_start" || event.type === "session_end") {
+    return { chat: 1 };
+  }
+  if (event.type === "compaction") {
+    return { planning: 1 };
+  }
+  if (event.type === "parse_error") {
+    return { chat: 0 };
+  }
+
+  return scores;
+}
+
+function isTestPath(p: string): boolean {
+  if (!p) return false;
+  return /(^|\/)(tests?|__tests__|spec)\//.test(p) || /\.(test|spec)\.[a-z0-9]+$/.test(p);
+}
+
+function isDocPath(p: string): boolean {
+  if (!p) return false;
+  if (/\.(md|mdx|rst|adoc|txt)$/.test(p)) return true;
+  if (/(^|\/)(docs?|guides?|examples?)\//.test(p)) return true;
+  if (/(^|\/)(readme|changelog|contributing|license|security|code_of_conduct)/i.test(p)) {
+    return true;
+  }
+  return false;
+}
+
+function isConfigPath(p: string): boolean {
+  if (!p) return false;
+  if (/\.(json|ya?ml|toml|ini|env|config\.[jt]s|cjs|mjs)$/.test(p)) return true;
+  if (/(^|\/)(\.env(?:\..*)?|tsconfig|tsup\.config|vitest\.config|vite\.config|jest\.config|babel\.config|webpack\.config|rollup\.config|prettier\.config|eslint\.config|tailwind\.config|postcss\.config)$/i.test(p)) {
+    return true;
+  }
+  if (/(^|\/)package\.json$/i.test(p)) return true;
+  return false;
+}

--- a/src/classify/index.ts
+++ b/src/classify/index.ts
@@ -1,0 +1,7 @@
+export {
+  classifyEvent,
+  scoreEvent,
+  ACTIVITY_CATEGORIES,
+  type ActivityCategory,
+} from "./activity.js";
+export { withClassifier } from "./sink.js";

--- a/src/classify/sink.ts
+++ b/src/classify/sink.ts
@@ -1,0 +1,24 @@
+import type { AgentEvent, EventDetails, EventSink } from "../schema.js";
+import { classifyEvent } from "./activity.js";
+
+/** Wraps an EventSink so every emitted event has `details.category`
+ *  attached before it propagates further. Idempotent — if a category
+ *  is already present we leave it (some upstream might have set a
+ *  better one).
+ *
+ *  Place this BEFORE the store wrapper so the categorization is
+ *  persisted alongside the event. */
+export function withClassifier(inner: EventSink): EventSink {
+  return {
+    emit: (event: AgentEvent) => {
+      if (!event.details) event.details = {};
+      if (!event.details.category) {
+        event.details.category = classifyEvent(event);
+      }
+      inner.emit(event);
+    },
+    enrich: (eventId: string, patch: Partial<EventDetails>) => {
+      inner.enrich(eventId, patch);
+    },
+  };
+}

--- a/src/daemon/daemon.test.ts
+++ b/src/daemon/daemon.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DAEMON_LABEL,
+  renderPlist,
+  renderSystemdUnit,
+  resolveAgentwatchExec,
+} from "./install.js";
+import { RotatingLogStream } from "./log-rotate.js";
+import { isProcessAlive } from "./run.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agentwatch-daemon-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("daemon — log rotation", () => {
+  it("appends to a fresh log file", () => {
+    const path = join(dir, "log");
+    const log = new RotatingLogStream({ path, maxBytes: 1024 });
+    log.write("hello");
+    log.write("world");
+    log.close();
+    const content = readFileSync(path, "utf-8");
+    expect(content).toBe("hello\nworld\n");
+  });
+
+  it("rotates when the next write would exceed maxBytes", () => {
+    const path = join(dir, "log");
+    const log = new RotatingLogStream({ path, maxBytes: 50 });
+    log.write("x".repeat(40)); // 41 bytes including trailing newline
+    log.write("y".repeat(40)); // would push us past 50 → rotate first
+    log.close();
+    expect(existsSync(`${path}.1`)).toBe(true);
+    const main = readFileSync(path, "utf-8");
+    const rotated = readFileSync(`${path}.1`, "utf-8");
+    expect(rotated).toContain("x".repeat(40));
+    expect(main).toContain("y".repeat(40));
+    expect(main.length).toBeLessThan(50);
+  });
+
+  it("creates the parent directory if missing", () => {
+    const nested = join(dir, "nested", "deeper", "log");
+    const log = new RotatingLogStream({ path: nested });
+    log.write("ok");
+    log.close();
+    expect(existsSync(nested)).toBe(true);
+  });
+
+  it("survives a re-open by appending, not truncating", () => {
+    const path = join(dir, "log");
+    let log = new RotatingLogStream({ path });
+    log.write("first");
+    log.close();
+    log = new RotatingLogStream({ path });
+    log.write("second");
+    log.close();
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("first");
+    expect(content).toContain("second");
+    expect(content.indexOf("first")).toBeLessThan(content.indexOf("second"));
+  });
+});
+
+describe("daemon — service unit rendering", () => {
+  it("renders a launchd plist with the daemon label and four-arg ProgramArguments", () => {
+    const plist = renderPlist(
+      { node: "/usr/local/bin/node", script: "/opt/agentwatch/bin/agentwatch.js" },
+      "/Users/x/.agentwatch/daemon.log",
+    );
+    expect(plist).toContain(`<string>${DAEMON_LABEL}</string>`);
+    expect(plist).toContain("<string>/usr/local/bin/node</string>");
+    expect(plist).toContain(
+      "<string>/opt/agentwatch/bin/agentwatch.js</string>",
+    );
+    expect(plist).toContain("<string>daemon</string>");
+    expect(plist).toContain("<string>run</string>");
+    expect(plist).toContain("<key>RunAtLoad</key>");
+    expect(plist).toContain("<key>KeepAlive</key>");
+    expect(plist).toContain(
+      "<string>/Users/x/.agentwatch/daemon.log</string>",
+    );
+  });
+
+  it("renders a systemd unit with simple type, restart-on-failure, and log redirect", () => {
+    const unit = renderSystemdUnit(
+      { node: "/usr/bin/node", script: "/opt/agentwatch/bin/agentwatch.js" },
+      "/home/x/.agentwatch/daemon.log",
+    );
+    expect(unit).toContain("Description=agentwatch event capture daemon");
+    expect(unit).toContain("Type=simple");
+    expect(unit).toContain(
+      "ExecStart=/usr/bin/node /opt/agentwatch/bin/agentwatch.js daemon run",
+    );
+    expect(unit).toContain("Restart=on-failure");
+    expect(unit).toContain("WantedBy=default.target");
+    expect(unit).toContain(
+      "StandardOutput=append:/home/x/.agentwatch/daemon.log",
+    );
+  });
+
+  it("resolveAgentwatchExec uses process.execPath + argv[1]", () => {
+    const exec = resolveAgentwatchExec();
+    expect(exec.node).toBe(process.execPath);
+    expect(exec.script.length).toBeGreaterThan(0);
+  });
+});
+
+describe("daemon — process liveness probe", () => {
+  it("reports the current process as alive", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it("reports a definitely-dead pid as not alive", () => {
+    // PID 0 is reserved (kernel scheduler) — process.kill rejects it.
+    // Use a high pid that's almost certainly unused.
+    expect(isProcessAlive(2_000_000_000)).toBe(false);
+  });
+});
+
+describe("daemon — log file size budget", () => {
+  it("never grows the active log past maxBytes by more than one line", () => {
+    const path = join(dir, "log");
+    const log = new RotatingLogStream({ path, maxBytes: 200 });
+    for (let i = 0; i < 50; i++) log.write(`line ${i} `.repeat(5));
+    log.close();
+    const size = statSync(path).size;
+    // After the last rotation, the active file holds only writes that
+    // came post-rotation. Bound is one full line over the cap.
+    expect(size).toBeLessThan(400);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { platform } from "node:os";
+import {
+  DAEMON_LABEL,
+  logPath,
+  pidFilePath,
+  plistPath,
+  removeServiceUnit,
+  startTimeFilePath,
+  systemdUnitPath,
+  writeServiceUnit,
+} from "./install.js";
+import { isProcessAlive, runDaemon } from "./run.js";
+
+const HELP = `agentwatch daemon — background event capture
+
+Usage:
+  agentwatch daemon start    install + load the user-level service
+  agentwatch daemon stop     unload the service (events.db is preserved)
+  agentwatch daemon status   running state + uptime + capture stats
+  agentwatch daemon logs     tail the daemon log
+  agentwatch daemon run      foreground mode (used by launchd / systemd)
+
+Service files:
+  macOS:  ~/Library/LaunchAgents/${DAEMON_LABEL}.plist
+  Linux:  ~/.config/systemd/user/agentwatch.service
+
+The daemon writes every adapter event to ~/.agentwatch/events.db. The
+TUI and \`agentwatch serve\` read the same store, so events captured
+overnight are visible the moment you open them.
+`;
+
+export async function dispatchDaemon(sub: string | undefined): Promise<void> {
+  switch (sub) {
+    case undefined:
+    case "--help":
+    case "-h":
+      console.log(HELP);
+      process.exit(0);
+      return;
+    case "start":
+      return startCmd();
+    case "stop":
+      return stopCmd();
+    case "status":
+      return statusCmd();
+    case "logs":
+      return logsCmd();
+    case "run":
+      await runDaemon();
+      return;
+    default:
+      process.stderr.write(`agentwatch daemon: unknown subcommand "${sub}"\n`);
+      process.stderr.write(HELP);
+      process.exit(2);
+  }
+}
+
+function startCmd(): void {
+  const result = writeServiceUnit();
+  console.log(`wrote service unit: ${result.unitPath}`);
+  if (platform() === "darwin") {
+    runStep(["launchctl", "unload", result.unitPath], { allowFail: true });
+    runStep(["launchctl", "load", "-w", result.unitPath]);
+    console.log(`daemon loaded — events stream into ~/.agentwatch/events.db`);
+    return;
+  }
+  if (platform() === "linux") {
+    runStep(["systemctl", "--user", "daemon-reload"]);
+    runStep(["systemctl", "--user", "enable", "--now", "agentwatch.service"]);
+    console.log(`daemon enabled + started`);
+    return;
+  }
+  console.log(`unsupported platform; manual steps:`);
+  for (const cmd of result.manualSteps) console.log(`  ${cmd}`);
+}
+
+function stopCmd(): void {
+  if (platform() === "darwin") {
+    const path = plistPath();
+    if (existsSync(path)) {
+      runStep(["launchctl", "unload", path], { allowFail: true });
+    }
+    const removed = removeServiceUnit();
+    console.log(`daemon stopped${removed.unitPath ? ` (removed ${removed.unitPath})` : ""}`);
+    return;
+  }
+  if (platform() === "linux") {
+    runStep(["systemctl", "--user", "disable", "--now", "agentwatch.service"], {
+      allowFail: true,
+    });
+    runStep(["systemctl", "--user", "daemon-reload"], { allowFail: true });
+    const removed = removeServiceUnit();
+    console.log(`daemon stopped${removed.unitPath ? ` (removed ${removed.unitPath})` : ""}`);
+    return;
+  }
+  console.log(`unsupported platform — kill the process manually`);
+}
+
+function statusCmd(): void {
+  const status = readDaemonStatus();
+  if (!status.running) {
+    console.log(`daemon: not running`);
+    if (status.unitInstalled) console.log(`unit installed at: ${status.unitPath}`);
+    process.exit(0);
+  }
+  console.log(`daemon: running (pid ${status.pid})`);
+  console.log(`uptime: ${formatUptime(status.uptimeMs)}`);
+  console.log(
+    `events captured: ${status.eventsCaptured}` +
+      (status.lastEventTs ? ` · last at ${status.lastEventTs}` : ""),
+  );
+  if (status.unitPath) console.log(`unit: ${status.unitPath}`);
+  if (status.dbBytes != null) {
+    console.log(`db size: ${(status.dbBytes / 1_048_576).toFixed(1)} MB`);
+  }
+}
+
+export interface DaemonStatus {
+  running: boolean;
+  pid?: number;
+  uptimeMs: number;
+  eventsCaptured: number;
+  lastEventTs?: string;
+  unitInstalled: boolean;
+  unitPath?: string;
+  dbBytes?: number;
+}
+
+export function readDaemonStatus(): DaemonStatus {
+  const pidFile = pidFilePath();
+  const unitPath =
+    platform() === "darwin"
+      ? plistPath()
+      : platform() === "linux"
+        ? systemdUnitPath()
+        : undefined;
+  const unitInstalled = unitPath ? existsSync(unitPath) : false;
+
+  let pid: number | undefined;
+  let uptimeMs = 0;
+  if (existsSync(pidFile)) {
+    const raw = readFileSync(pidFile, "utf-8").trim();
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0 && isProcessAlive(parsed)) {
+      pid = parsed;
+    }
+  }
+  if (pid && existsSync(startTimeFilePath())) {
+    const startMs = Number(readFileSync(startTimeFilePath(), "utf-8").trim());
+    if (Number.isFinite(startMs)) uptimeMs = Math.max(0, Date.now() - startMs);
+  }
+
+  let eventsCaptured = 0;
+  let lastEventTs: string | undefined;
+  let dbBytes: number | undefined;
+  try {
+    // Lazy require so a missing better-sqlite3 (rare) doesn't break status.
+    const { openStore } = require("../store/sqlite.js") as typeof import("../store/sqlite.js");
+    const store = openStore();
+    const stats = store.stats();
+    eventsCaptured = stats.events;
+    dbBytes = stats.dbBytes;
+    const sessions = store.listSessions({ limit: 1 });
+    lastEventTs = sessions[0]?.lastTs;
+    store.close();
+  } catch {
+    // store unreachable; report what we know
+  }
+
+  return {
+    running: pid != null,
+    ...(pid != null ? { pid } : {}),
+    uptimeMs,
+    eventsCaptured,
+    ...(lastEventTs ? { lastEventTs } : {}),
+    unitInstalled,
+    ...(unitPath ? { unitPath } : {}),
+    ...(dbBytes != null ? { dbBytes } : {}),
+  };
+}
+
+function logsCmd(): void {
+  const path = logPath();
+  if (!existsSync(path)) {
+    console.log(`(no log yet at ${path})`);
+    return;
+  }
+  // Use tail -f if available; fall back to printing the file.
+  const tail = spawnSync("tail", ["-n", "200", "-f", path], {
+    stdio: "inherit",
+  });
+  if (tail.error) {
+    process.stdout.write(readFileSync(path, "utf-8"));
+  }
+}
+
+function runStep(
+  argv: string[],
+  opts: { allowFail?: boolean } = {},
+): void {
+  const [cmd, ...rest] = argv;
+  if (!cmd) return;
+  const result = spawnSync(cmd, rest, { stdio: "inherit" });
+  if (result.error) {
+    if (opts.allowFail) return;
+    throw new Error(`spawn ${cmd}: ${String(result.error)}`);
+  }
+  if (result.status !== 0 && !opts.allowFail) {
+    throw new Error(`${argv.join(" ")} exited ${result.status}`);
+  }
+}
+
+function formatUptime(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`;
+  if (ms < 86_400_000) {
+    const h = Math.floor(ms / 3_600_000);
+    const m = Math.floor((ms % 3_600_000) / 60_000);
+    return `${h}h ${m}m`;
+  }
+  const d = Math.floor(ms / 86_400_000);
+  const h = Math.floor((ms % 86_400_000) / 3_600_000);
+  return `${d}d ${h}h`;
+}

--- a/src/daemon/install.ts
+++ b/src/daemon/install.ts
@@ -1,0 +1,140 @@
+import { homedir, platform } from "node:os";
+import { join, resolve } from "node:path";
+import { existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+
+export const DAEMON_LABEL = "com.agentwatch.daemon";
+
+export interface DaemonExec {
+  /** Absolute path to the node binary that should run the daemon. */
+  node: string;
+  /** Absolute path to the agentwatch entry script (bin/agentwatch.js or src/index.tsx). */
+  script: string;
+}
+
+export function resolveAgentwatchExec(): DaemonExec {
+  return {
+    node: process.execPath,
+    script: resolve(process.argv[1] ?? ""),
+  };
+}
+
+export function plistPath(): string {
+  return join(homedir(), "Library", "LaunchAgents", `${DAEMON_LABEL}.plist`);
+}
+
+export function systemdUnitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", "agentwatch.service");
+}
+
+export function logPath(): string {
+  return join(homedir(), ".agentwatch", "daemon.log");
+}
+
+export function pidFilePath(): string {
+  return join(homedir(), ".agentwatch", "daemon.pid");
+}
+
+export function startTimeFilePath(): string {
+  return join(homedir(), ".agentwatch", "daemon.started_at");
+}
+
+export function renderPlist(exec: DaemonExec, log: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${DAEMON_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${exec.node}</string>
+    <string>${exec.script}</string>
+    <string>daemon</string>
+    <string>run</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${log}</string>
+  <key>StandardErrorPath</key>
+  <string>${log}</string>
+</dict>
+</plist>
+`;
+}
+
+export function renderSystemdUnit(exec: DaemonExec, log: string): string {
+  return `[Unit]
+Description=agentwatch event capture daemon
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${exec.node} ${exec.script} daemon run
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:${log}
+StandardError=append:${log}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export interface InstallResult {
+  unitPath: string;
+  /** Shell commands the operator should run if our spawn() failed (e.g.
+   *  no launchctl on PATH). Empty when the install fully succeeded. */
+  manualSteps: string[];
+}
+
+export function writeServiceUnit(): InstallResult {
+  const exec = resolveAgentwatchExec();
+  const log = logPath();
+  mkdirSync(join(homedir(), ".agentwatch"), { recursive: true });
+  if (platform() === "darwin") {
+    const path = plistPath();
+    mkdirSync(join(homedir(), "Library", "LaunchAgents"), { recursive: true });
+    writeFileSync(path, renderPlist(exec, log), "utf-8");
+    return {
+      unitPath: path,
+      manualSteps: [`launchctl load -w ${path}`],
+    };
+  }
+  if (platform() === "linux") {
+    const path = systemdUnitPath();
+    mkdirSync(join(homedir(), ".config", "systemd", "user"), { recursive: true });
+    writeFileSync(path, renderSystemdUnit(exec, log), "utf-8");
+    return {
+      unitPath: path,
+      manualSteps: [
+        "systemctl --user daemon-reload",
+        "systemctl --user enable --now agentwatch.service",
+      ],
+    };
+  }
+  throw new Error(
+    `agentwatch daemon: unsupported platform "${platform()}" (Windows is on the v0.2 roadmap)`,
+  );
+}
+
+export function removeServiceUnit(): { unitPath: string | null } {
+  const path = platform() === "darwin"
+    ? plistPath()
+    : platform() === "linux"
+      ? systemdUnitPath()
+      : null;
+  if (!path) return { unitPath: null };
+  if (existsSync(path)) {
+    try {
+      unlinkSync(path);
+    } catch {
+      // best effort
+    }
+  }
+  return { unitPath: path };
+}

--- a/src/daemon/log-rotate.ts
+++ b/src/daemon/log-rotate.ts
@@ -1,0 +1,73 @@
+import { closeSync, openSync, renameSync, statSync, writeSync } from "node:fs";
+import { dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+
+/** Append-only log writer with a single rotation slot.
+ *
+ *  When the current log size exceeds `maxBytes`, the file is renamed to
+ *  `<path>.1` (overwriting any previous one) and a fresh `<path>` is
+ *  opened. The daemon never holds a long-running write stream — every
+ *  `write` is `writeSync` so we don't have to drain on shutdown.
+ *
+ *  Single rotation slot is intentional: ten megabytes of history is the
+ *  upper bound, plus a recent ten in `.1`. Anything older isn't worth
+ *  the disk. Operators who want longer history pipe the log to a
+ *  separate journal. */
+export class RotatingLogStream {
+  private fd: number;
+  private bytes: number;
+  private readonly path: string;
+  private readonly maxBytes: number;
+
+  constructor(opts: { path: string; maxBytes?: number }) {
+    this.path = opts.path;
+    this.maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+    mkdirSync(dirname(this.path), { recursive: true });
+    this.fd = openSync(this.path, "a");
+    try {
+      this.bytes = statSync(this.path).size;
+    } catch {
+      this.bytes = 0;
+    }
+  }
+
+  write(line: string): void {
+    const buf = Buffer.from(line.endsWith("\n") ? line : `${line}\n`);
+    if (this.bytes + buf.length > this.maxBytes) {
+      this.rotate();
+    }
+    writeSync(this.fd, buf);
+    this.bytes += buf.length;
+  }
+
+  /** Test seam — read current bytes-on-disk for assertions. */
+  byteCount(): number {
+    return this.bytes;
+  }
+
+  close(): void {
+    try {
+      closeSync(this.fd);
+    } catch {
+      // already closed
+    }
+  }
+
+  private rotate(): void {
+    try {
+      closeSync(this.fd);
+    } catch {
+      // already closed
+    }
+    try {
+      renameSync(this.path, `${this.path}.1`);
+    } catch {
+      // best effort — if rename fails (e.g. read-only fs) just keep
+      // appending and let an operator handle it.
+    }
+    this.fd = openSync(this.path, "a");
+    this.bytes = 0;
+  }
+}

--- a/src/daemon/run.ts
+++ b/src/daemon/run.ts
@@ -1,0 +1,192 @@
+import {
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logPath, pidFilePath, startTimeFilePath } from "./install.js";
+import { RotatingLogStream } from "./log-rotate.js";
+import type { AgentEvent, EventDetails, EventSink } from "../schema.js";
+import { clampTs } from "../schema.js";
+
+/** Run the daemon as a foreground process. The launchd plist / systemd
+ *  unit invokes `agentwatch daemon run` and treats this as the long-
+ *  running supervised process; KeepAlive / Restart handles crash loops.
+ *
+ *  Responsibilities here:
+ *    1. Open the SQLite store
+ *    2. Start every adapter wired through wrapSinkWithStore so events
+ *       persist on disk
+ *    3. Write our PID + start time so `daemon status` can read them
+ *    4. Drain on SIGTERM / SIGINT — close adapters, close store
+ *    5. Stay alive until signaled
+ *
+ *  No TUI, no web server, no notifications. The TUI and `agentwatch
+ *  serve` are clients of the same SQLite store; they observe daemon-
+ *  written events transparently. */
+export async function runDaemon(): Promise<void> {
+  const dataDir = join(homedir(), ".agentwatch");
+  mkdirSync(dataDir, { recursive: true });
+
+  const lock = acquireLock();
+  if (!lock.ok) {
+    process.stderr.write(
+      `[agentwatch daemon] another instance is already running (pid ${lock.existingPid}). Exiting.\n`,
+    );
+    process.exit(2);
+  }
+
+  const log = new RotatingLogStream({ path: logPath() });
+  const logLine = (msg: string): void => {
+    log.write(`${new Date().toISOString()} ${msg}`);
+  };
+  logLine(`daemon starting (pid ${process.pid})`);
+
+  let store: import("../store/sqlite.js").EventStore | null = null;
+  let stoppingHooks: Array<() => Promise<void> | void> = [];
+
+  try {
+    const { openStore, wrapSinkWithStore } = await import("../store/index.js");
+    const { startAllAdapters, stopAllAdapters } = await import(
+      "../adapters/registry.js"
+    );
+    const { detectWorkspaceRoot } = await import("../util/workspace.js");
+
+    store = openStore();
+    const workspace = detectWorkspaceRoot();
+
+    let captured = 0;
+    const inner: EventSink = {
+      emit: (e: AgentEvent) => {
+        e.ts = clampTs(e.ts);
+        captured += 1;
+      },
+      enrich: (_id: string, _patch: Partial<EventDetails>) => {
+        // Daemon-side enrich is purely a store update — handled by the
+        // wrapper; nothing additional to do here.
+      },
+    };
+    const sink = wrapSinkWithStore(inner, store);
+    const adapters = startAllAdapters(sink, workspace);
+    stoppingHooks.push(() => stopAllAdapters(adapters));
+    stoppingHooks.push(() => store?.close());
+
+    logLine(`adapters started; workspace=${workspace}`);
+
+    // Periodic heartbeat to the log so operators can confirm the daemon
+    // is healthy without parsing PID-state. Once a minute is enough.
+    const heartbeat = setInterval(() => {
+      logLine(`heartbeat captured=${captured}`);
+    }, 60_000);
+    heartbeat.unref();
+    stoppingHooks.push(() => clearInterval(heartbeat));
+
+    setupShutdown(stoppingHooks, log, lock.releaseLock);
+
+    // Block forever — adapters keep the event loop alive via their
+    // chokidar watchers. We add a never-resolving promise as a belt and
+    // suspenders so an adapter shutting down cleanly doesn't drop us.
+    await new Promise<void>(() => undefined);
+  } catch (err) {
+    logLine(`fatal: ${String(err)}`);
+    for (const hook of stoppingHooks) {
+      try {
+        await hook();
+      } catch {
+        // best effort
+      }
+    }
+    lock.releaseLock();
+    log.close();
+    process.exit(1);
+  }
+}
+
+interface LockHandle {
+  ok: boolean;
+  existingPid?: number;
+  releaseLock: () => void;
+}
+
+function acquireLock(): LockHandle {
+  const pidFile = pidFilePath();
+  const startFile = startTimeFilePath();
+  if (existsSync(pidFile)) {
+    const raw = readFileSync(pidFile, "utf-8").trim();
+    const pid = Number(raw);
+    if (Number.isFinite(pid) && pid > 0 && isProcessAlive(pid)) {
+      return { ok: false, existingPid: pid, releaseLock: () => undefined };
+    }
+    // Stale PID file — remove it and continue.
+    try {
+      unlinkSync(pidFile);
+    } catch {
+      // best effort
+    }
+  }
+  mkdirSync(dirname(pidFile), { recursive: true });
+  writeFileSync(pidFile, String(process.pid), "utf-8");
+  writeFileSync(startFile, String(Date.now()), "utf-8");
+  return {
+    ok: true,
+    releaseLock: () => {
+      try {
+        unlinkSync(pidFile);
+      } catch {
+        // best effort
+      }
+      try {
+        unlinkSync(startFile);
+      } catch {
+        // best effort
+      }
+    },
+  };
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the process exists but we can't signal it — still alive.
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+function setupShutdown(
+  hooks: Array<() => Promise<void> | void>,
+  log: RotatingLogStream,
+  releaseLock: () => void,
+): void {
+  let shutting = false;
+  const stop = async (sig: string): Promise<void> => {
+    if (shutting) return;
+    shutting = true;
+    log.write(
+      `${new Date().toISOString()} shutdown signal=${sig} draining ${hooks.length} hooks\n`,
+    );
+    for (const hook of hooks) {
+      try {
+        await hook();
+      } catch (err) {
+        log.write(
+          `${new Date().toISOString()} shutdown hook error: ${String(err)}\n`,
+        );
+      }
+    }
+    releaseLock();
+    log.write(`${new Date().toISOString()} daemon stopped cleanly\n`);
+    log.close();
+    process.exit(0);
+  };
+  process.on("SIGTERM", () => void stop("SIGTERM"));
+  process.on("SIGINT", () => void stop("SIGINT"));
+  process.on("SIGHUP", () => void stop("SIGHUP"));
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ Usage:
   agentwatch serve          run only the web server (no TUI, for remote boxes)
   agentwatch doctor         detect installed agents and print readiness
   agentwatch mcp            run as an MCP server over stdio
+  agentwatch prune          drop events older than --older-than-days (default 90)
   agentwatch --help         show this help
 
 Flags:
@@ -57,6 +58,26 @@ if (arg === "mcp") {
     process.stderr.write(`[agentwatch] mcp error: ${String(err)}\n`);
     process.exit(1);
   }
+  process.exit(0);
+}
+
+if (arg === "prune") {
+  const { openStore } = await import("./store/index.js");
+  const days = Number(parseFlag("--older-than-days") ?? "90");
+  if (!Number.isFinite(days) || days < 0) {
+    process.stderr.write(
+      `[agentwatch] prune: --older-than-days must be a non-negative number, got ${days}\n`,
+    );
+    process.exit(2);
+  }
+  const store = openStore();
+  const result = store.prune({ olderThanDays: days });
+  const stats = store.stats();
+  store.close();
+  console.log(
+    `pruned ${result.deletedEvents} events / ${result.deletedSessions} sessions older than ${days}d ` +
+      `(${stats.events} events / ${stats.sessions} sessions / ${(stats.dbBytes / 1_048_576).toFixed(1)} MB remaining)`,
+  );
   process.exit(0);
 }
 
@@ -96,12 +117,25 @@ if (arg === "serve") {
   );
   const { detectWorkspaceRoot } = await import("./util/workspace.js");
   const { clampTs } = await import("./schema.js");
+  const { openStore, wrapSinkWithStore } = await import("./store/index.js");
   const workspace = detectWorkspaceRoot();
   const host = parseFlag("--host") ?? process.env.AGENTWATCH_HOST ?? "127.0.0.1";
   const port = Number(parseFlag("--port") ?? process.env.AGENTWATCH_PORT ?? 3456);
   const { addEventToServer } = await import("./server/index.js");
-  const server = await startServer({ host, port });
-  const sink = {
+  let store: ReturnType<typeof openStore> | null = null;
+  try {
+    store = openStore();
+  } catch (err) {
+    process.stderr.write(
+      `[agentwatch] event store unavailable: ${String(err)}\n`,
+    );
+  }
+  const server = await startServer({
+    host,
+    port,
+    ...(store ? { store } : {}),
+  });
+  const innerSink = {
     emit: (e: import("./schema.js").AgentEvent) => {
       e.ts = clampTs(e.ts);
       addEventToServer(server, e);
@@ -118,9 +152,11 @@ if (arg === "serve") {
       server.broadcaster.emitEnrich(eventId, patch);
     },
   };
+  const sink = store ? wrapSinkWithStore(innerSink, store) : innerSink;
   const adapters = startAllAdapters(sink, workspace);
   onShutdown(() => stopAllAdapters(adapters));
   onShutdown(() => server.stop());
+  if (store) onShutdown(() => store?.close());
   process.stderr.write(`[agentwatch] serving ${server.url}\n`);
   // Signal handling happens at the bottom of this file via the global
   // shutdown-hooks wiring; the serve path just registers its cleanup.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -161,7 +161,9 @@ if (arg === "serve") {
       server.broadcaster.emitEnrich(eventId, patch);
     },
   };
-  const sink = store ? wrapSinkWithStore(innerSink, store) : innerSink;
+  const { withClassifier } = await import("./classify/index.js");
+  const persistSink = store ? wrapSinkWithStore(innerSink, store) : innerSink;
+  const sink = withClassifier(persistSink);
   const adapters = startAllAdapters(sink, workspace);
   onShutdown(() => stopAllAdapters(adapters));
   onShutdown(() => server.stop());

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,8 @@ Usage:
   agentwatch serve          run only the web server (no TUI, for remote boxes)
   agentwatch doctor         detect installed agents and print readiness
   agentwatch mcp            run as an MCP server over stdio
+  agentwatch daemon ...     install + manage the background capture service
+                              (subcommands: start | stop | status | logs)
   agentwatch prune          drop events older than --older-than-days (default 90)
   agentwatch --help         show this help
 
@@ -58,6 +60,13 @@ if (arg === "mcp") {
     process.stderr.write(`[agentwatch] mcp error: ${String(err)}\n`);
     process.exit(1);
   }
+  process.exit(0);
+}
+
+if (arg === "daemon") {
+  const { dispatchDaemon } = await import("./daemon/index.js");
+  await dispatchDaemon(process.argv[3]);
+  // dispatchDaemon either exits or runs forever; if it returns we're done.
   process.exit(0);
 }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -103,6 +103,22 @@ export interface EventDetails {
   parseErrorCount?: number;
   /** Truncated preview of the most recent unparseable line. */
   parseErrorSample?: string;
+  /** Activity category — one of ACTIVITY_CATEGORIES. Heuristically assigned
+   *  on emit by the classify wrapper (AUR-264). Used by the per-session
+   *  and per-project activity views to answer "where is my spend going?". */
+  category?:
+    | "coding"
+    | "debugging"
+    | "exploration"
+    | "planning"
+    | "refactor"
+    | "testing"
+    | "docs"
+    | "chat"
+    | "config"
+    | "review"
+    | "devops"
+    | "research";
 }
 
 /** Sink passed to adapters. Adapters emit new events and may later

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { registerAgentRoutes } from "./routes/agents.js";
 import { registerPermissionRoutes } from "./routes/permissions.js";
 import { registerCronRoutes } from "./routes/cron.js";
 import { registerSearchRoutes } from "./routes/search.js";
+import { registerActivityRoutes } from "./routes/activity.js";
 import type { EventStore } from "../store/sqlite.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerTrendsRoutes } from "./routes/trends.js";
@@ -154,6 +155,7 @@ export async function startServer(opts: StartServerOptions): Promise<ServerHandl
   registerPermissionRoutes(app);
   registerCronRoutes(app, events);
   registerSearchRoutes(app, events, opts.store);
+  registerActivityRoutes(app, opts.store);
   registerConfigRoutes(app);
   registerTrendsRoutes(app, events);
   registerDiffRoutes(app, events);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { registerAgentRoutes } from "./routes/agents.js";
 import { registerPermissionRoutes } from "./routes/permissions.js";
 import { registerCronRoutes } from "./routes/cron.js";
 import { registerSearchRoutes } from "./routes/search.js";
+import type { EventStore } from "../store/sqlite.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerTrendsRoutes } from "./routes/trends.js";
 import { registerDiffRoutes } from "./routes/diffs.js";
@@ -34,6 +35,11 @@ export interface ServerHandle {
   events: AgentEvent[];
   /** Rebuild `events` from `byAgent`. Cheap enough at our scale. */
   rebuildFlat: () => void;
+  /** Persistent SQLite store, if one was passed at startup. Routes that
+   *  need full history (e.g. search history mode) read from this; the
+   *  in-memory ring buffer remains the source of truth for the SSE live
+   *  stream. */
+  store?: EventStore;
   stop: () => Promise<void>;
 }
 
@@ -41,6 +47,7 @@ export interface StartServerOptions {
   host?: string;
   port?: number;
   events?: AgentEvent[]; // optional; kept for back-compat
+  store?: EventStore;
 }
 
 const DEFAULT_HOST = "127.0.0.1";
@@ -146,7 +153,7 @@ export async function startServer(opts: StartServerOptions): Promise<ServerHandl
   registerAgentRoutes(app, events, byAgent);
   registerPermissionRoutes(app);
   registerCronRoutes(app, events);
-  registerSearchRoutes(app, events);
+  registerSearchRoutes(app, events, opts.store);
   registerConfigRoutes(app);
   registerTrendsRoutes(app, events);
   registerDiffRoutes(app, events);
@@ -180,6 +187,7 @@ export async function startServer(opts: StartServerOptions): Promise<ServerHandl
     byAgent,
     events,
     rebuildFlat,
+    store: opts.store,
     stop: async () => {
       broadcaster.closeAll();
       await app.close();

--- a/src/server/routes/activity.ts
+++ b/src/server/routes/activity.ts
@@ -1,0 +1,29 @@
+import type { FastifyInstance } from "fastify";
+import type { EventStore } from "../../store/sqlite.js";
+
+/** Per-category activity rollups for a session or project. Routes return
+ *  empty arrays when no store is attached or no matching data exists —
+ *  the UI is responsible for showing an empty-state instead of a 404,
+ *  because "this session has zero events of any category" is meaningful. */
+export function registerActivityRoutes(
+  app: FastifyInstance,
+  store?: EventStore,
+): void {
+  app.get<{ Params: { id: string } }>(
+    "/api/sessions/:id/activity",
+    async (req) => {
+      const id = decodeURIComponent(req.params.id);
+      if (!store) return { sessionId: id, buckets: [] };
+      return { sessionId: id, buckets: store.activityBySession(id) };
+    },
+  );
+
+  app.get<{ Params: { name: string } }>(
+    "/api/projects/:name/activity",
+    async (req) => {
+      const name = decodeURIComponent(req.params.name);
+      if (!store) return { project: name, buckets: [] };
+      return { project: name, buckets: store.activityByProject(name) };
+    },
+  );
+}

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -1,10 +1,11 @@
 import type { FastifyInstance } from "fastify";
 import type { AgentEvent } from "../../schema.js";
 import { searchAllSessions } from "../../util/cross-search.js";
+import type { EventStore } from "../../store/sqlite.js";
 
 interface SearchBody {
   query: string;
-  mode?: "live" | "cross" | "semantic";
+  mode?: "live" | "cross" | "semantic" | "history";
   limit?: number;
   /** Optional ISO timestamps narrowing the window (cross mode only — live
    *  is ring-buffer scoped already). */
@@ -17,7 +18,11 @@ interface SearchBody {
 /* Timestamp extraction lives in cross-search.ts/sniffTs — hits carry
  * a `ts` field when the JSONL line included one. */
 
-export function registerSearchRoutes(app: FastifyInstance, events: AgentEvent[]): void {
+export function registerSearchRoutes(
+  app: FastifyInstance,
+  events: AgentEvent[],
+  store?: EventStore,
+): void {
   app.post<{ Body: SearchBody }>("/api/search", async (req, reply) => {
     const query = (req.body?.query ?? "").trim();
     const mode = req.body?.mode ?? "live";
@@ -36,6 +41,29 @@ export function registerSearchRoutes(app: FastifyInstance, events: AgentEvent[])
         if (matchesLive(e, needle)) hits.push(e);
       }
       return { mode, hits: hits.map((e) => ({ kind: "live" as const, event: e })) };
+    }
+
+    if (mode === "history") {
+      if (!store) {
+        return {
+          mode,
+          hits: [],
+          status: "history mode requires a SQLite store — pass --no-web off and ensure ~/.agentwatch is writable",
+        };
+      }
+      const hits = store.searchFts(query, { limit }).map((h) => ({
+        kind: "history" as const,
+        hit: {
+          eventId: h.eventId,
+          sessionId: h.sessionId,
+          agent: h.agent,
+          ts: h.ts,
+          type: h.type,
+          snippet: h.snippet,
+          rank: h.rank,
+        },
+      }));
+      return { mode, hits };
     }
 
     if (mode === "cross") {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,5 +8,6 @@ export {
   type ListSessionsOptions,
   type PruneResult,
   type StoreStats,
+  type ActivityBucket,
 } from "./sqlite.js";
 export { wrapSinkWithStore } from "./wire.js";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,12 @@
+export {
+  openStore,
+  DEFAULT_DB_PATH,
+  type EventStore,
+  type SessionSummary,
+  type ProjectSummary,
+  type FtsHit,
+  type ListSessionsOptions,
+  type PruneResult,
+  type StoreStats,
+} from "./sqlite.js";
+export { wrapSinkWithStore } from "./wire.js";

--- a/src/store/sqlite.test.ts
+++ b/src/store/sqlite.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 
 describe("sqlite store — schema + lifecycle", () => {
   it("initializes schema_version to current", () => {
-    expect(store.stats().schemaVersion).toBe(1);
+    expect(store.stats().schemaVersion).toBeGreaterThanOrEqual(1);
   });
 
   it("re-opening an existing db is idempotent (CREATE IF NOT EXISTS)", () => {
@@ -309,6 +309,80 @@ describe("sqlite store — prune", () => {
     const sessions = store.listSessions().map((s) => s.sessionId);
     expect(sessions).not.toContain("old-s");
     expect(sessions).toContain("new-s");
+  });
+});
+
+describe("sqlite store — activity rollups (v2)", () => {
+  it("activityBySession buckets events by category with counts and cost", () => {
+    store.insertMany([
+      makeEvent({
+        id: "a1",
+        sessionId: "act-s",
+        details: { category: "coding", cost: 0.10 },
+      }),
+      makeEvent({
+        id: "a2",
+        sessionId: "act-s",
+        details: { category: "coding", cost: 0.05 },
+      }),
+      makeEvent({
+        id: "a3",
+        sessionId: "act-s",
+        details: { category: "testing", cost: 0.02 },
+      }),
+      makeEvent({
+        id: "a4",
+        sessionId: "other-s",
+        details: { category: "coding", cost: 0.99 },
+      }),
+    ]);
+    const buckets = store.activityBySession("act-s");
+    const coding = buckets.find((b) => b.category === "coding");
+    const testing = buckets.find((b) => b.category === "testing");
+    expect(coding?.eventCount).toBe(2);
+    expect(coding?.costUsd).toBeCloseTo(0.15);
+    expect(testing?.eventCount).toBe(1);
+    expect(buckets[0]?.category).toBe("coding"); // sorted by count
+  });
+
+  it("activityByProject aggregates across sessions of one project", () => {
+    store.insertMany([
+      makeEvent({
+        id: "p1",
+        sessionId: "s1",
+        summary: "[bpi] do work",
+        details: { category: "coding", cost: 0.10 },
+      }),
+      makeEvent({
+        id: "p2",
+        sessionId: "s2",
+        summary: "[bpi] more work",
+        details: { category: "coding", cost: 0.20 },
+      }),
+      makeEvent({
+        id: "p3",
+        sessionId: "s3",
+        summary: "[other] not us",
+        details: { category: "coding", cost: 0.99 },
+      }),
+    ]);
+    const buckets = store.activityByProject("bpi");
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]?.category).toBe("coding");
+    expect(buckets[0]?.eventCount).toBe(2);
+    expect(buckets[0]?.costUsd).toBeCloseTo(0.30);
+  });
+
+  it("uses 'chat' as the bucket label for events without a category", () => {
+    store.insert(
+      makeEvent({
+        id: "u1",
+        sessionId: "u-sess",
+        details: { cost: 0.01 },
+      }),
+    );
+    const buckets = store.activityBySession("u-sess");
+    expect(buckets[0]?.category).toBe("chat");
   });
 });
 

--- a/src/store/sqlite.test.ts
+++ b/src/store/sqlite.test.ts
@@ -1,0 +1,342 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentEvent } from "../schema.js";
+import { openStore, type EventStore } from "./sqlite.js";
+
+let dir: string;
+let store: EventStore;
+
+function makeEvent(over: Partial<AgentEvent> = {}): AgentEvent {
+  return {
+    id: over.id ?? `evt-${Math.random().toString(36).slice(2, 10)}`,
+    ts: over.ts ?? new Date().toISOString(),
+    agent: over.agent ?? "claude-code",
+    type: over.type ?? "tool_call",
+    path: over.path,
+    cmd: over.cmd,
+    tool: over.tool,
+    summary: over.summary,
+    sessionId: over.sessionId,
+    promptId: over.promptId,
+    riskScore: over.riskScore ?? 1,
+    details: over.details,
+  };
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agentwatch-store-"));
+  store = openStore({ dbPath: join(dir, "events.db") });
+});
+
+afterEach(() => {
+  store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("sqlite store — schema + lifecycle", () => {
+  it("initializes schema_version to current", () => {
+    expect(store.stats().schemaVersion).toBe(1);
+  });
+
+  it("re-opening an existing db is idempotent (CREATE IF NOT EXISTS)", () => {
+    const first = store.stats();
+    store.close();
+    store = openStore({ dbPath: join(dir, "events.db") });
+    const second = store.stats();
+    expect(second.schemaVersion).toBe(first.schemaVersion);
+  });
+});
+
+describe("sqlite store — insert + dedup", () => {
+  it("stores an event and reads it back", () => {
+    const e = makeEvent({
+      id: "evt-a",
+      summary: "[auraqu] Edit src/foo.ts",
+      sessionId: "sess-1",
+      details: { fullText: "hello world", cost: 0.05, model: "opus-4-6" },
+    });
+    store.insert(e);
+    const back = store.getEvent("evt-a");
+    expect(back).not.toBeNull();
+    expect(back?.summary).toBe("[auraqu] Edit src/foo.ts");
+    expect(back?.details?.cost).toBeCloseTo(0.05);
+    expect(back?.details?.fullText).toBe("hello world");
+  });
+
+  it("dedups on event id (INSERT OR IGNORE)", () => {
+    const e = makeEvent({ id: "dup", sessionId: "s1" });
+    store.insert(e);
+    store.insert(e);
+    store.insert(e);
+    const events = store.listSessionEvents("s1");
+    expect(events).toHaveLength(1);
+  });
+
+  it("listSessionEvents returns events ordered by ts ascending", () => {
+    store.insert(
+      makeEvent({ id: "a", ts: "2026-05-01T10:00:00Z", sessionId: "s2" }),
+    );
+    store.insert(
+      makeEvent({ id: "b", ts: "2026-05-01T09:00:00Z", sessionId: "s2" }),
+    );
+    store.insert(
+      makeEvent({ id: "c", ts: "2026-05-01T11:00:00Z", sessionId: "s2" }),
+    );
+    const ids = store.listSessionEvents("s2").map((e) => e.id);
+    expect(ids).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("sqlite store — session aggregation trigger", () => {
+  it("creates a sessions row when the first event of a session arrives", () => {
+    store.insert(
+      makeEvent({
+        id: "s-evt-1",
+        sessionId: "sess-x",
+        ts: "2026-05-01T10:00:00Z",
+        summary: "[bpi] working",
+        details: { cost: 0.02 },
+      }),
+    );
+    const sessions = store.listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: "sess-x",
+      project: "bpi",
+      eventCount: 1,
+    });
+    expect(sessions[0]?.costUsd).toBeCloseTo(0.02);
+  });
+
+  it("accumulates cost + extends the time range as more events arrive", () => {
+    store.insert(
+      makeEvent({
+        id: "e1",
+        sessionId: "s",
+        ts: "2026-05-01T10:00:00Z",
+        details: { cost: 0.1 },
+      }),
+    );
+    store.insert(
+      makeEvent({
+        id: "e2",
+        sessionId: "s",
+        ts: "2026-05-01T11:00:00Z",
+        details: { cost: 0.2 },
+      }),
+    );
+    store.insert(
+      makeEvent({
+        id: "e3",
+        sessionId: "s",
+        ts: "2026-05-01T09:30:00Z",
+        details: { cost: 0.05 },
+      }),
+    );
+    const [s] = store.listSessions();
+    expect(s?.eventCount).toBe(3);
+    expect(s?.firstTs).toBe("2026-05-01T09:30:00Z");
+    expect(s?.lastTs).toBe("2026-05-01T11:00:00Z");
+    expect(s?.costUsd).toBeCloseTo(0.35);
+  });
+
+  it("filters listSessions by agent + project + since", () => {
+    store.insert(
+      makeEvent({
+        id: "x1",
+        sessionId: "sess-a",
+        agent: "claude-code",
+        ts: "2026-04-01T10:00:00Z",
+        summary: "[proj-1] hi",
+      }),
+    );
+    store.insert(
+      makeEvent({
+        id: "x2",
+        sessionId: "sess-b",
+        agent: "codex",
+        ts: "2026-05-01T10:00:00Z",
+        summary: "[proj-2] hi",
+      }),
+    );
+    expect(store.listSessions({ agent: "codex" })).toHaveLength(1);
+    expect(store.listSessions({ project: "proj-1" })).toHaveLength(1);
+    expect(
+      store.listSessions({ since: "2026-04-15T00:00:00Z" }),
+    ).toHaveLength(1);
+  });
+});
+
+describe("sqlite store — enrich", () => {
+  it("merges patch into details_json + bumps session cost when cost changes", () => {
+    store.insert(
+      makeEvent({
+        id: "evt-rich",
+        sessionId: "rs",
+        details: { fullText: "before", cost: 0.0 },
+      }),
+    );
+    store.enrich("evt-rich", {
+      toolResult: "stdout output here",
+      cost: 0.42,
+      durationMs: 1234,
+    });
+    const back = store.getEvent("evt-rich");
+    expect(back?.details?.toolResult).toBe("stdout output here");
+    expect(back?.details?.cost).toBeCloseTo(0.42);
+    expect(back?.details?.fullText).toBe("before");
+    const [s] = store.listSessions();
+    expect(s?.costUsd).toBeCloseTo(0.42);
+  });
+
+  it("enrich on non-existent event id is a no-op", () => {
+    expect(() =>
+      store.enrich("does-not-exist", { toolResult: "x" }),
+    ).not.toThrow();
+  });
+});
+
+describe("sqlite store — listProjects", () => {
+  it("aggregates per project across agents and sessions", () => {
+    store.insertMany([
+      makeEvent({
+        id: "p1",
+        agent: "claude-code",
+        sessionId: "s1",
+        summary: "[auraqu] one",
+        details: { cost: 0.1 },
+      }),
+      makeEvent({
+        id: "p2",
+        agent: "codex",
+        sessionId: "s2",
+        summary: "[auraqu] two",
+        details: { cost: 0.2 },
+      }),
+      makeEvent({
+        id: "p3",
+        agent: "claude-code",
+        sessionId: "s3",
+        summary: "[bpi] three",
+      }),
+    ]);
+    const projects = store.listProjects();
+    const auraqu = projects.find((p) => p.name === "auraqu");
+    expect(auraqu).toBeDefined();
+    expect(auraqu?.eventCount).toBe(2);
+    expect(auraqu?.byAgent["claude-code"]).toBe(1);
+    expect(auraqu?.byAgent.codex).toBe(1);
+    expect(auraqu?.cost).toBeCloseTo(0.3);
+    expect(auraqu?.sessionIds.sort()).toEqual(["s1", "s2"]);
+  });
+});
+
+describe("sqlite store — fts5 search", () => {
+  it("matches by full text content with snippet markers", () => {
+    store.insert(
+      makeEvent({
+        id: "f1",
+        sessionId: "sf",
+        details: {
+          fullText: "the quick brown fox jumps over the lazy dog",
+        },
+      }),
+    );
+    store.insert(
+      makeEvent({
+        id: "f2",
+        sessionId: "sf",
+        details: { fullText: "an unrelated message about cats" },
+      }),
+    );
+    const hits = store.searchFts("brown fox");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.eventId).toBe("f1");
+    expect(hits[0]?.snippet).toContain("<<");
+    expect(hits[0]?.snippet).toContain(">>");
+  });
+
+  it("sanitizes FTS-special characters so user input doesn't crash", () => {
+    store.insert(
+      makeEvent({
+        id: "g1",
+        details: { fullText: "needle in haystack" },
+      }),
+    );
+    const hits = store.searchFts('"NEEDLE" AND OR -');
+    expect(hits.map((h) => h.eventId)).toContain("g1");
+  });
+
+  it("empty / whitespace-only query returns []", () => {
+    expect(store.searchFts("")).toEqual([]);
+    expect(store.searchFts("   ")).toEqual([]);
+  });
+});
+
+describe("sqlite store — tool_call enrichment", () => {
+  it("enrich updates duration + error fields on a tool event", () => {
+    store.insert(
+      makeEvent({
+        id: "tc1",
+        type: "shell_exec",
+        tool: "Bash",
+        cmd: "ls -la",
+      }),
+    );
+    store.enrich("tc1", { durationMs: 99, toolError: true });
+    const back = store.getEvent("tc1");
+    expect(back?.details?.durationMs).toBe(99);
+    expect(back?.details?.toolError).toBe(true);
+  });
+});
+
+describe("sqlite store — prune", () => {
+  it("deletes events older than the cutoff and their session aggregates", () => {
+    const oldTs = new Date(Date.now() - 100 * 86_400_000).toISOString();
+    const recentTs = new Date(Date.now() - 1 * 86_400_000).toISOString();
+    store.insert(
+      makeEvent({ id: "old", sessionId: "old-s", ts: oldTs }),
+    );
+    store.insert(
+      makeEvent({ id: "new", sessionId: "new-s", ts: recentTs }),
+    );
+    const result = store.prune({ olderThanDays: 90 });
+    expect(result.deletedEvents).toBe(1);
+    expect(store.getEvent("old")).toBeNull();
+    expect(store.getEvent("new")).not.toBeNull();
+    const sessions = store.listSessions().map((s) => s.sessionId);
+    expect(sessions).not.toContain("old-s");
+    expect(sessions).toContain("new-s");
+  });
+});
+
+describe("sqlite store — bench (10k events)", () => {
+  it(
+    "ingests 10k events in under 2s",
+    () => {
+      const events: AgentEvent[] = [];
+      for (let i = 0; i < 10_000; i++) {
+        events.push(
+          makeEvent({
+            id: `b-${i}`,
+            sessionId: `bench-s-${i % 50}`,
+            ts: new Date(Date.now() - i * 1000).toISOString(),
+            summary: `[bench] turn ${i}`,
+            details: {
+              fullText: `event number ${i} body content for fts`,
+              cost: 0.001,
+            },
+          }),
+        );
+      }
+      const t0 = performance.now();
+      store.insertMany(events);
+      const elapsed = performance.now() - t0;
+      expect(elapsed).toBeLessThan(2000);
+      expect(store.stats().events).toBe(10_000);
+    },
+    10_000,
+  );
+});

--- a/src/store/sqlite.ts
+++ b/src/store/sqlite.ts
@@ -1,0 +1,590 @@
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { AgentEvent, AgentName, EventDetails, EventType } from "../schema.js";
+
+export interface SessionSummary {
+  sessionId: string;
+  agent: AgentName;
+  project: string | null;
+  firstTs: string;
+  lastTs: string;
+  eventCount: number;
+  costUsd: number;
+}
+
+export interface ProjectSummary {
+  name: string;
+  eventCount: number;
+  byAgent: Record<string, number>;
+  sessionIds: string[];
+  cost: number;
+  lastTs: string;
+}
+
+export interface FtsHit {
+  eventId: string;
+  sessionId: string | null;
+  agent: AgentName;
+  ts: string;
+  type: EventType;
+  snippet: string;
+  rank: number;
+}
+
+export interface ListSessionsOptions {
+  limit?: number;
+  agent?: AgentName;
+  project?: string;
+  since?: string;
+}
+
+export interface PruneResult {
+  deletedEvents: number;
+  deletedSessions: number;
+}
+
+export interface StoreStats {
+  events: number;
+  sessions: number;
+  dbBytes: number;
+  schemaVersion: number;
+}
+
+export interface EventStore {
+  insert(event: AgentEvent): void;
+  insertMany(events: AgentEvent[]): void;
+  enrich(eventId: string, patch: Partial<EventDetails>): void;
+  hasEvent(eventId: string): boolean;
+  getEvent(eventId: string): AgentEvent | null;
+  listSessionEvents(sessionId: string): AgentEvent[];
+  listSessions(opts?: ListSessionsOptions): SessionSummary[];
+  listProjects(): ProjectSummary[];
+  searchFts(query: string, opts?: { limit?: number }): FtsHit[];
+  prune(opts: { olderThanDays: number }): PruneResult;
+  stats(): StoreStats;
+  close(): void;
+}
+
+const SCHEMA_VERSION = 1;
+
+export const DEFAULT_DB_PATH = join(homedir(), ".agentwatch", "events.db");
+
+export function openStore(opts: { dbPath?: string } = {}): EventStore {
+  const dbPath = opts.dbPath ?? DEFAULT_DB_PATH;
+  if (dbPath !== ":memory:") {
+    mkdirSync(dirname(dbPath), { recursive: true });
+  }
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("synchronous = NORMAL");
+  db.pragma("foreign_keys = ON");
+  applyMigrations(db);
+  return buildStore(db);
+}
+
+function applyMigrations(db: Database.Database): void {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY)`,
+  );
+  const row = db
+    .prepare("SELECT version FROM schema_version LIMIT 1")
+    .get() as { version: number } | undefined;
+  const current = row?.version ?? 0;
+  if (current < 1) applyV1(db);
+  // Future versions: if (current < 2) applyV2(db);
+  db.prepare(
+    "INSERT OR REPLACE INTO schema_version (version) VALUES (?)",
+  ).run(SCHEMA_VERSION);
+}
+
+function applyV1(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS events (
+      id TEXT PRIMARY KEY,
+      ts TEXT NOT NULL,
+      agent TEXT NOT NULL,
+      type TEXT NOT NULL,
+      path TEXT,
+      cmd TEXT,
+      tool TEXT,
+      summary TEXT,
+      session_id TEXT,
+      prompt_id TEXT,
+      risk_score INTEGER NOT NULL,
+      project TEXT,
+      details_json TEXT,
+      full_text TEXT,
+      thinking TEXT,
+      tool_input_json TEXT,
+      tool_result TEXT,
+      cost_usd REAL,
+      model TEXT,
+      duration_ms INTEGER,
+      tool_error INTEGER,
+      sub_agent_id TEXT,
+      parent_spawn_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
+    CREATE INDEX IF NOT EXISTS idx_events_agent ON events(agent);
+    CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
+    CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
+    CREATE INDEX IF NOT EXISTS idx_events_session_ts ON events(session_id, ts);
+    CREATE INDEX IF NOT EXISTS idx_events_project ON events(project);
+
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      agent TEXT NOT NULL,
+      project TEXT,
+      first_ts TEXT NOT NULL,
+      last_ts TEXT NOT NULL,
+      event_count INTEGER NOT NULL DEFAULT 0,
+      cost_usd REAL NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent);
+    CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);
+    CREATE INDEX IF NOT EXISTS idx_sessions_last_ts ON sessions(last_ts);
+
+    CREATE TABLE IF NOT EXISTS tool_calls (
+      event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+      tool TEXT NOT NULL,
+      duration_ms INTEGER,
+      error INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_tool ON tool_calls(tool);
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(
+      full_text, thinking, tool_result, summary,
+      content='events',
+      content_rowid='rowid',
+      tokenize='porter unicode61'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS events_ai AFTER INSERT ON events BEGIN
+      INSERT INTO events_fts(rowid, full_text, thinking, tool_result, summary)
+      VALUES (new.rowid, new.full_text, new.thinking, new.tool_result, new.summary);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS events_ad AFTER DELETE ON events BEGIN
+      INSERT INTO events_fts(events_fts, rowid, full_text, thinking, tool_result, summary)
+      VALUES ('delete', old.rowid, old.full_text, old.thinking, old.tool_result, old.summary);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS events_au AFTER UPDATE ON events BEGIN
+      INSERT INTO events_fts(events_fts, rowid, full_text, thinking, tool_result, summary)
+      VALUES ('delete', old.rowid, old.full_text, old.thinking, old.tool_result, old.summary);
+      INSERT INTO events_fts(rowid, full_text, thinking, tool_result, summary)
+      VALUES (new.rowid, new.full_text, new.thinking, new.tool_result, new.summary);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS sessions_upsert_on_event_insert
+    AFTER INSERT ON events
+    WHEN new.session_id IS NOT NULL BEGIN
+      INSERT INTO sessions (session_id, agent, project, first_ts, last_ts, event_count, cost_usd)
+      VALUES (new.session_id, new.agent, new.project, new.ts, new.ts, 1, COALESCE(new.cost_usd, 0))
+      ON CONFLICT(session_id) DO UPDATE SET
+        last_ts = CASE WHEN new.ts > last_ts THEN new.ts ELSE last_ts END,
+        first_ts = CASE WHEN new.ts < first_ts THEN new.ts ELSE first_ts END,
+        event_count = event_count + 1,
+        cost_usd = cost_usd + COALESCE(new.cost_usd, 0),
+        project = COALESCE(sessions.project, new.project),
+        updated_at = strftime('%s','now');
+    END;
+  `);
+}
+
+function buildStore(db: Database.Database): EventStore {
+  const insertStmt = db.prepare(`
+    INSERT OR IGNORE INTO events (
+      id, ts, agent, type, path, cmd, tool, summary,
+      session_id, prompt_id, risk_score, project, details_json,
+      full_text, thinking, tool_input_json, tool_result,
+      cost_usd, model, duration_ms, tool_error,
+      sub_agent_id, parent_spawn_id
+    )
+    VALUES (
+      @id, @ts, @agent, @type, @path, @cmd, @tool, @summary,
+      @session_id, @prompt_id, @risk_score, @project, @details_json,
+      @full_text, @thinking, @tool_input_json, @tool_result,
+      @cost_usd, @model, @duration_ms, @tool_error,
+      @sub_agent_id, @parent_spawn_id
+    )
+  `);
+
+  const insertToolCallStmt = db.prepare(`
+    INSERT OR REPLACE INTO tool_calls (event_id, tool, duration_ms, error)
+    VALUES (?, ?, ?, ?)
+  `);
+
+  const getStmt = db.prepare(
+    `SELECT * FROM events WHERE id = ?`,
+  );
+
+  const hasStmt = db.prepare(`SELECT 1 FROM events WHERE id = ?`);
+
+  const sessionEventsStmt = db.prepare(
+    `SELECT * FROM events WHERE session_id = ? ORDER BY ts ASC`,
+  );
+
+  const insertMany = db.transaction((events: AgentEvent[]) => {
+    for (const e of events) doInsert(e);
+  });
+
+  function doInsert(event: AgentEvent): void {
+    const d = event.details ?? {};
+    const project = extractProject(event);
+    const params = {
+      id: event.id,
+      ts: event.ts,
+      agent: event.agent,
+      type: event.type,
+      path: event.path ?? null,
+      cmd: event.cmd ?? null,
+      tool: event.tool ?? null,
+      summary: event.summary ?? null,
+      session_id: event.sessionId ?? null,
+      prompt_id: event.promptId ?? null,
+      risk_score: event.riskScore,
+      project,
+      details_json: d ? JSON.stringify(d) : null,
+      full_text: d.fullText ?? null,
+      thinking: d.thinking ?? null,
+      tool_input_json: d.toolInput ? JSON.stringify(d.toolInput) : null,
+      tool_result: d.toolResult ?? null,
+      cost_usd: d.cost ?? null,
+      model: d.model ?? null,
+      duration_ms: d.durationMs ?? null,
+      tool_error: d.toolError == null ? null : d.toolError ? 1 : 0,
+      sub_agent_id: d.subAgentId ?? null,
+      parent_spawn_id: d.parentSpawnId ?? null,
+    };
+    const info = insertStmt.run(params);
+    if (info.changes > 0 && event.tool) {
+      insertToolCallStmt.run(
+        event.id,
+        event.tool,
+        d.durationMs ?? null,
+        d.toolError ? 1 : 0,
+      );
+    }
+  }
+
+  const enrichSelectStmt = db.prepare(
+    `SELECT details_json, cost_usd FROM events WHERE id = ?`,
+  );
+
+  const enrichUpdateStmt = db.prepare(`
+    UPDATE events SET
+      details_json = @details_json,
+      full_text = COALESCE(@full_text, full_text),
+      thinking = COALESCE(@thinking, thinking),
+      tool_input_json = COALESCE(@tool_input_json, tool_input_json),
+      tool_result = COALESCE(@tool_result, tool_result),
+      cost_usd = COALESCE(@cost_usd, cost_usd),
+      model = COALESCE(@model, model),
+      duration_ms = COALESCE(@duration_ms, duration_ms),
+      tool_error = COALESCE(@tool_error, tool_error)
+    WHERE id = @id
+  `);
+
+  const sessionCostBumpStmt = db.prepare(`
+    UPDATE sessions SET cost_usd = cost_usd + ?, updated_at = strftime('%s','now')
+    WHERE session_id = (SELECT session_id FROM events WHERE id = ?)
+  `);
+
+  function doEnrich(eventId: string, patch: Partial<EventDetails>): void {
+    const row = enrichSelectStmt.get(eventId) as
+      | { details_json: string | null; cost_usd: number | null }
+      | undefined;
+    if (!row) return;
+    const prev = row.details_json ? (JSON.parse(row.details_json) as EventDetails) : {};
+    const merged: EventDetails = { ...prev, ...patch };
+    enrichUpdateStmt.run({
+      id: eventId,
+      details_json: JSON.stringify(merged),
+      full_text: patch.fullText ?? null,
+      thinking: patch.thinking ?? null,
+      tool_input_json: patch.toolInput ? JSON.stringify(patch.toolInput) : null,
+      tool_result: patch.toolResult ?? null,
+      cost_usd: patch.cost ?? null,
+      model: patch.model ?? null,
+      duration_ms: patch.durationMs ?? null,
+      tool_error:
+        patch.toolError == null ? null : patch.toolError ? 1 : 0,
+    });
+    // Cost arrives via enrich for some adapters (toolResult pairing); reflect
+    // it in the session aggregate so listSessions stays correct.
+    if (patch.cost && patch.cost !== row.cost_usd) {
+      const delta = patch.cost - (row.cost_usd ?? 0);
+      sessionCostBumpStmt.run(delta, eventId);
+    }
+    if (patch.durationMs != null || patch.toolError != null) {
+      const eventRow = db
+        .prepare("SELECT tool FROM events WHERE id = ?")
+        .get(eventId) as { tool: string | null } | undefined;
+      if (eventRow?.tool) {
+        insertToolCallStmt.run(
+          eventId,
+          eventRow.tool,
+          merged.durationMs ?? null,
+          merged.toolError ? 1 : 0,
+        );
+      }
+    }
+  }
+
+  return {
+    insert: doInsert,
+    insertMany: (events) => insertMany(events),
+    enrich: doEnrich,
+    hasEvent(eventId) {
+      return Boolean(hasStmt.get(eventId));
+    },
+    getEvent(eventId) {
+      const row = getStmt.get(eventId) as RawEventRow | undefined;
+      return row ? rowToEvent(row) : null;
+    },
+    listSessionEvents(sessionId) {
+      const rows = sessionEventsStmt.all(sessionId) as RawEventRow[];
+      return rows.map(rowToEvent);
+    },
+    listSessions(opts = {}) {
+      const limit = clamp(opts.limit ?? 200, 1, 5000);
+      const where: string[] = [];
+      const params: unknown[] = [];
+      if (opts.agent) {
+        where.push("agent = ?");
+        params.push(opts.agent);
+      }
+      if (opts.project) {
+        where.push("project = ?");
+        params.push(opts.project);
+      }
+      if (opts.since) {
+        where.push("last_ts >= ?");
+        params.push(opts.since);
+      }
+      const sql = `
+        SELECT session_id, agent, project, first_ts, last_ts, event_count, cost_usd
+        FROM sessions
+        ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+        ORDER BY last_ts DESC
+        LIMIT ?
+      `;
+      const rows = db.prepare(sql).all(...params, limit) as Array<{
+        session_id: string;
+        agent: AgentName;
+        project: string | null;
+        first_ts: string;
+        last_ts: string;
+        event_count: number;
+        cost_usd: number;
+      }>;
+      return rows.map((r) => ({
+        sessionId: r.session_id,
+        agent: r.agent,
+        project: r.project,
+        firstTs: r.first_ts,
+        lastTs: r.last_ts,
+        eventCount: r.event_count,
+        costUsd: r.cost_usd,
+      }));
+    },
+    listProjects() {
+      const rows = db
+        .prepare(
+          `SELECT project, agent, COUNT(*) AS event_count, MAX(ts) AS last_ts,
+                  COALESCE(SUM(cost_usd), 0) AS cost_total, session_id
+           FROM events
+           WHERE project IS NOT NULL
+           GROUP BY project, agent, session_id`,
+        )
+        .all() as Array<{
+        project: string;
+        agent: AgentName;
+        event_count: number;
+        last_ts: string;
+        cost_total: number;
+        session_id: string | null;
+      }>;
+      const byProject = new Map<string, ProjectSummary>();
+      for (const r of rows) {
+        let p = byProject.get(r.project);
+        if (!p) {
+          p = {
+            name: r.project,
+            eventCount: 0,
+            byAgent: {},
+            sessionIds: [],
+            cost: 0,
+            lastTs: r.last_ts,
+          };
+          byProject.set(r.project, p);
+        }
+        p.eventCount += r.event_count;
+        p.byAgent[r.agent] = (p.byAgent[r.agent] ?? 0) + r.event_count;
+        if (r.session_id && !p.sessionIds.includes(r.session_id)) {
+          p.sessionIds.push(r.session_id);
+        }
+        p.cost += r.cost_total ?? 0;
+        if (r.last_ts > p.lastTs) p.lastTs = r.last_ts;
+      }
+      return Array.from(byProject.values()).sort((a, b) =>
+        a.lastTs < b.lastTs ? 1 : -1,
+      );
+    },
+    searchFts(query, opts = {}) {
+      const limit = clamp(opts.limit ?? 100, 1, 500);
+      const safe = sanitizeFtsQuery(query);
+      if (!safe) return [];
+      const rows = db
+        .prepare(
+          `SELECT e.id AS id, e.session_id AS session_id, e.agent AS agent,
+                  e.ts AS ts, e.type AS type, fts.rank AS rank,
+                  snippet(events_fts, -1, '<<', '>>', '…', 16) AS snip
+           FROM events_fts AS fts
+           JOIN events AS e ON e.rowid = fts.rowid
+           WHERE events_fts MATCH ?
+           ORDER BY rank
+           LIMIT ?`,
+        )
+        .all(safe, limit) as Array<{
+        id: string;
+        session_id: string | null;
+        agent: AgentName;
+        ts: string;
+        type: EventType;
+        rank: number;
+        snip: string;
+      }>;
+      return rows.map((r) => ({
+        eventId: r.id,
+        sessionId: r.session_id,
+        agent: r.agent,
+        ts: r.ts,
+        type: r.type,
+        snippet: r.snip,
+        rank: r.rank,
+      }));
+    },
+    prune({ olderThanDays }) {
+      const cutoffMs = Date.now() - olderThanDays * 86_400_000;
+      const cutoff = new Date(cutoffMs).toISOString();
+      const events = db
+        .prepare(`DELETE FROM events WHERE ts < ?`)
+        .run(cutoff);
+      const sessions = db
+        .prepare(`DELETE FROM sessions WHERE last_ts < ?`)
+        .run(cutoff);
+      // VACUUM is expensive; we use incremental_vacuum via auto_vacuum if set,
+      // else a one-shot only for non-tiny prunes.
+      if (events.changes > 1000) {
+        try {
+          db.exec("VACUUM");
+        } catch {
+          // VACUUM in WAL mode may transiently fail under contention; not fatal.
+        }
+      }
+      return {
+        deletedEvents: Number(events.changes),
+        deletedSessions: Number(sessions.changes),
+      };
+    },
+    stats() {
+      const eventCount = (
+        db.prepare("SELECT COUNT(*) AS c FROM events").get() as { c: number }
+      ).c;
+      const sessionCount = (
+        db.prepare("SELECT COUNT(*) AS c FROM sessions").get() as {
+          c: number;
+        }
+      ).c;
+      const pages = (
+        db.prepare("PRAGMA page_count").get() as { page_count: number }
+      ).page_count;
+      const pageSize = (
+        db.prepare("PRAGMA page_size").get() as { page_size: number }
+      ).page_size;
+      const versionRow = db
+        .prepare("SELECT version FROM schema_version LIMIT 1")
+        .get() as { version: number } | undefined;
+      return {
+        events: eventCount,
+        sessions: sessionCount,
+        dbBytes: pages * pageSize,
+        schemaVersion: versionRow?.version ?? 0,
+      };
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+interface RawEventRow {
+  id: string;
+  ts: string;
+  agent: AgentName;
+  type: EventType;
+  path: string | null;
+  cmd: string | null;
+  tool: string | null;
+  summary: string | null;
+  session_id: string | null;
+  prompt_id: string | null;
+  risk_score: number;
+  project: string | null;
+  details_json: string | null;
+}
+
+function rowToEvent(row: RawEventRow): AgentEvent {
+  const details = row.details_json
+    ? (JSON.parse(row.details_json) as EventDetails)
+    : undefined;
+  return {
+    id: row.id,
+    ts: row.ts,
+    agent: row.agent,
+    type: row.type,
+    path: row.path ?? undefined,
+    cmd: row.cmd ?? undefined,
+    tool: row.tool ?? undefined,
+    summary: row.summary ?? undefined,
+    sessionId: row.session_id ?? undefined,
+    promptId: row.prompt_id ?? undefined,
+    riskScore: row.risk_score,
+    details,
+  };
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function extractProject(e: AgentEvent): string | null {
+  const m = (e.summary ?? "").match(/^\[([^\]/ ]+)/);
+  return m ? (m[1] ?? null) : null;
+}
+
+// FTS5 reserved characters or stray boolean operators crash the parser.
+// Strip everything but word chars + spaces, drop FTS5 keywords that the
+// user usually typed incidentally, then OR the remaining tokens for
+// search-as-you-type recall. Empty result means no query.
+const FTS_KEYWORDS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+function sanitizeFtsQuery(q: string): string {
+  const cleaned = q
+    .replace(/[^\p{L}\p{N}\s_-]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return "";
+  const tokens = cleaned
+    .split(" ")
+    .filter((t) => t.length > 0 && !FTS_KEYWORDS.has(t.toUpperCase()))
+    .map((t) => `"${t}"`);
+  if (tokens.length === 0) return "";
+  return tokens.join(" OR ");
+}

--- a/src/store/sqlite.ts
+++ b/src/store/sqlite.ts
@@ -52,6 +52,12 @@ export interface StoreStats {
   schemaVersion: number;
 }
 
+export interface ActivityBucket {
+  category: string;
+  eventCount: number;
+  costUsd: number;
+}
+
 export interface EventStore {
   insert(event: AgentEvent): void;
   insertMany(events: AgentEvent[]): void;
@@ -62,12 +68,16 @@ export interface EventStore {
   listSessions(opts?: ListSessionsOptions): SessionSummary[];
   listProjects(): ProjectSummary[];
   searchFts(query: string, opts?: { limit?: number }): FtsHit[];
+  /** Per-category event count + cost for a single session. */
+  activityBySession(sessionId: string): ActivityBucket[];
+  /** Per-category event count + cost across every session in a project. */
+  activityByProject(projectName: string): ActivityBucket[];
   prune(opts: { olderThanDays: number }): PruneResult;
   stats(): StoreStats;
   close(): void;
 }
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 export const DEFAULT_DB_PATH = join(homedir(), ".agentwatch", "events.db");
 
@@ -93,10 +103,26 @@ function applyMigrations(db: Database.Database): void {
     .get() as { version: number } | undefined;
   const current = row?.version ?? 0;
   if (current < 1) applyV1(db);
-  // Future versions: if (current < 2) applyV2(db);
+  if (current < 2) applyV2(db);
   db.prepare(
     "INSERT OR REPLACE INTO schema_version (version) VALUES (?)",
   ).run(SCHEMA_VERSION);
+}
+
+function applyV2(db: Database.Database): void {
+  // AUR-264: per-event activity category. ALTER TABLE adds the column;
+  // FTS5 doesn't reference category so the existing triggers stay valid.
+  // Idempotent — duplicate-column on a re-applied migration is swallowed.
+  try {
+    db.exec(`ALTER TABLE events ADD COLUMN category TEXT`);
+  } catch (err) {
+    if (!String(err).includes("duplicate column name")) throw err;
+  }
+  try {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_events_category ON events(category)`);
+  } catch {
+    // best effort
+  }
 }
 
 function applyV1(db: Database.Database): void {
@@ -203,14 +229,14 @@ function buildStore(db: Database.Database): EventStore {
       session_id, prompt_id, risk_score, project, details_json,
       full_text, thinking, tool_input_json, tool_result,
       cost_usd, model, duration_ms, tool_error,
-      sub_agent_id, parent_spawn_id
+      sub_agent_id, parent_spawn_id, category
     )
     VALUES (
       @id, @ts, @agent, @type, @path, @cmd, @tool, @summary,
       @session_id, @prompt_id, @risk_score, @project, @details_json,
       @full_text, @thinking, @tool_input_json, @tool_result,
       @cost_usd, @model, @duration_ms, @tool_error,
-      @sub_agent_id, @parent_spawn_id
+      @sub_agent_id, @parent_spawn_id, @category
     )
   `);
 
@@ -260,6 +286,7 @@ function buildStore(db: Database.Database): EventStore {
       tool_error: d.toolError == null ? null : d.toolError ? 1 : 0,
       sub_agent_id: d.subAgentId ?? null,
       parent_spawn_id: d.parentSpawnId ?? null,
+      category: d.category ?? null,
     };
     const info = insertStmt.run(params);
     if (info.changes > 0 && event.tool) {
@@ -469,6 +496,52 @@ function buildStore(db: Database.Database): EventStore {
         snippet: r.snip,
         rank: r.rank,
       }));
+    },
+    activityBySession(sessionId) {
+      const rows = db
+        .prepare(
+          `SELECT COALESCE(category, 'chat') AS category,
+                  COUNT(*) AS event_count,
+                  COALESCE(SUM(cost_usd), 0) AS cost_total
+           FROM events
+           WHERE session_id = ?
+           GROUP BY COALESCE(category, 'chat')`,
+        )
+        .all(sessionId) as Array<{
+        category: string;
+        event_count: number;
+        cost_total: number;
+      }>;
+      return rows
+        .map((r) => ({
+          category: r.category,
+          eventCount: r.event_count,
+          costUsd: r.cost_total,
+        }))
+        .sort((a, b) => b.eventCount - a.eventCount);
+    },
+    activityByProject(projectName) {
+      const rows = db
+        .prepare(
+          `SELECT COALESCE(category, 'chat') AS category,
+                  COUNT(*) AS event_count,
+                  COALESCE(SUM(cost_usd), 0) AS cost_total
+           FROM events
+           WHERE project = ?
+           GROUP BY COALESCE(category, 'chat')`,
+        )
+        .all(projectName) as Array<{
+        category: string;
+        event_count: number;
+        cost_total: number;
+      }>;
+      return rows
+        .map((r) => ({
+          category: r.category,
+          eventCount: r.event_count,
+          costUsd: r.cost_total,
+        }))
+        .sort((a, b) => b.eventCount - a.eventCount);
     },
     prune({ olderThanDays }) {
       const cutoffMs = Date.now() - olderThanDays * 86_400_000;

--- a/src/store/wire.ts
+++ b/src/store/wire.ts
@@ -1,0 +1,45 @@
+import type { EventDetails, EventSink } from "../schema.js";
+import type { EventStore } from "./sqlite.js";
+
+/** Wraps an existing EventSink so every emit/enrich is mirrored into the
+ *  SQLite store. The store is the persistent source of truth; the inner
+ *  sink continues to drive the in-memory TUI/SSE pipeline.
+ *
+ *  Failures in the store path are logged once per failure-mode and never
+ *  propagated — observability must not crash the agent runtime when, e.g.,
+ *  the disk is full or the WAL is locked. */
+export function wrapSinkWithStore(
+  inner: EventSink,
+  store: EventStore,
+): EventSink {
+  let warnedInsert = false;
+  let warnedEnrich = false;
+  return {
+    emit: (event) => {
+      try {
+        store.insert(event);
+      } catch (err) {
+        if (!warnedInsert) {
+          warnedInsert = true;
+          process.stderr.write(
+            `[agentwatch] store.insert error (further occurrences suppressed): ${String(err)}\n`,
+          );
+        }
+      }
+      inner.emit(event);
+    },
+    enrich: (eventId: string, patch: Partial<EventDetails>) => {
+      try {
+        store.enrich(eventId, patch);
+      } catch (err) {
+        if (!warnedEnrich) {
+          warnedEnrich = true;
+          process.stderr.write(
+            `[agentwatch] store.enrich error (further occurrences suppressed): ${String(err)}\n`,
+          );
+        }
+      }
+      inner.enrich(eventId, patch);
+    },
+  };
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -26,6 +26,7 @@ import { startServer, type ServerHandle, addEventToServer } from "../server/inde
 import { openUrl } from "../util/open-url.js";
 import { onShutdown } from "../util/shutdown.js";
 import { openStore, wrapSinkWithStore, type EventStore } from "../store/index.js";
+import { withClassifier } from "../classify/index.js";
 
 /**
  * agentwatch TUI — live log tail.
@@ -158,7 +159,8 @@ export function App() {
         }
       },
     };
-    const finalSink = store ? wrapSinkWithStore(sink, store) : sink;
+    const persistSink = store ? wrapSinkWithStore(sink, store) : sink;
+    const finalSink = withClassifier(persistSink);
     const adapters = startAllAdapters(finalSink, workspace);
     const unregisterShutdown = onShutdown(() => {
       flush();

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -25,6 +25,7 @@ import { initialState, matchesQuery, reducer } from "./state.js";
 import { startServer, type ServerHandle, addEventToServer } from "../server/index.js";
 import { openUrl } from "../util/open-url.js";
 import { onShutdown } from "../util/shutdown.js";
+import { openStore, wrapSinkWithStore, type EventStore } from "../store/index.js";
 
 /**
  * agentwatch TUI — live log tail.
@@ -45,11 +46,35 @@ export function App() {
   const { stdout } = useStdout();
   const [state, dispatch] = useReducer(reducer, undefined, initialState);
   const [server, setServer] = useState<ServerHandle | null>(null);
+  const [store, setStore] = useState<EventStore | null>(null);
   const noWeb = process.argv.includes("--no-web");
+
+  // Persistent SQLite store — opened once, drains on shutdown. Failure to
+  // open (e.g. read-only home dir) leaves store=null; the rest of the TUI
+  // continues to work against the in-memory ring buffer.
+  useEffect(() => {
+    let s: EventStore | null = null;
+    let unregister: (() => void) | null = null;
+    try {
+      s = openStore();
+      setStore(s);
+      unregister = onShutdown(() => s?.close());
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[agentwatch] event store unavailable: ${String(err)}`);
+    }
+    return () => {
+      unregister?.();
+      if (s) {
+        try { s.close(); } catch { /* already closed */ }
+      }
+    };
+  }, []);
 
   // Server lifecycle — started once, lives as long as the TUI does.
   useEffect(() => {
     if (noWeb) return;
+    if (!store) return; // wait for the store before starting the server
     const events: AgentEvent[] = [];
     const port = Number(
       findFlag("--port") ?? process.env.AGENTWATCH_PORT ?? 3456,
@@ -58,7 +83,7 @@ export function App() {
     let handle: ServerHandle | null = null;
     let cancelled = false;
     let unregister: (() => void) | null = null;
-    startServer({ host, port, events })
+    startServer({ host, port, events, store })
       .then((h) => {
         if (cancelled) {
           void h.stop();
@@ -77,7 +102,7 @@ export function App() {
       unregister?.();
       if (handle) void handle.stop();
     };
-  }, []);
+  }, [store]);
 
   useEffect(() => {
     const stopTriggersWatch = watchTriggers();
@@ -133,7 +158,8 @@ export function App() {
         }
       },
     };
-    const adapters = startAllAdapters(sink, workspace);
+    const finalSink = store ? wrapSinkWithStore(sink, store) : sink;
+    const adapters = startAllAdapters(finalSink, workspace);
     const unregisterShutdown = onShutdown(() => {
       flush();
       stopAllAdapters(adapters);
@@ -145,7 +171,7 @@ export function App() {
       stopAllAdapters(adapters);
       stopTriggersWatch();
     };
-  }, [workspace, server]);
+  }, [workspace, server, store]);
 
   const agentFiltered = state.filterAgent
     ? state.events.filter((e) => e.agent === state.filterAgent)


### PR DESCRIPTION
## Summary

Adds `src/store/sqlite.ts` as the persistent source of truth for every event the adapters emit. Replaces the 4 MB rolling backfill with an indexed, queryable, FTS5-searchable store at `~/.agentwatch/events.db`.

**Schema (versioned migrations):**
- `events` — canonical `AgentEvent` shape, 22 columns + JSON blob for the rest of `details`. Indexes on session_id, agent, ts, type, project, plus a composite (session_id, ts).
- `sessions` — auto-aggregated via an `AFTER INSERT` trigger on `events`: first_ts / last_ts / event_count / cost_usd / project. Saves a separate write path.
- `tool_calls` — FK to events, columns tool / duration_ms / error.
- `events_fts` — FTS5 virtual table over `full_text + thinking + tool_result + summary` with `porter unicode61` tokenization. Triggers keep it in sync with `events`.

**Pragmas:** `journal_mode=WAL`, `synchronous=NORMAL`, `foreign_keys=ON`.

**Public API** (`src/store/index.ts`): `openStore`, `EventStore`, `wrapSinkWithStore`, plus the `SessionSummary` / `ProjectSummary` / `FtsHit` types. Methods: `insert`, `insertMany`, `enrich`, `getEvent`, `listSessionEvents`, `listSessions(opts)`, `listProjects`, `searchFts`, `prune`, `stats`, `close`.

**Wired into both TUI and `serve` mode** via `wrapSinkWithStore(innerSink, store)` — every emit/enrich is mirrored to SQLite. Store failures are logged once and never propagated; the in-memory pipeline remains the source of truth for the live SSE stream.

**New CLI:** `agentwatch prune --older-than-days N` (default 90). Drops old rows, VACUUMs on non-trivial prunes, prints resulting size.

**New search mode:** `POST /api/search` with `mode: "history"` hits the FTS5 index — full-history matches with rank + snippets, distinct from `live` (ring buffer), `cross` (JSONL scan), `semantic` (BM25+embeddings).

## Out of scope (filed as follow-ups)

- **TUI reducer becoming a thin cache over the store.** The reducer currently merges the SSE stream + 4 MB backfill into the live timeline; making it a SQLite-backed view changes the entire `useReducer`/dispatch flow. Best done as its own PR with focused tests.
- **Full `/sessions/*` and `/projects` route migration.** Those routes currently filter `events: AgentEvent[]` slices that are also driving the SSE broadcaster's per-agent ring buffer. Migrating them piecemeal is fine; doing it in this PR balloons review surface.
- **End-user schema migration tooling.** v1 ships a single schema; future bumps will land with proper `applyV2(db)` blocks behind the existing `applyMigrations` gate.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **279/279** pass (was 262, added 17)
  - schema + lifecycle (init / re-open idempotent)
  - insert + dedup (INSERT OR IGNORE on PK)
  - listSessionEvents ordering
  - session aggregation trigger (cost accumulates, ts range extends)
  - listSessions filter by agent / project / since
  - enrich merges into details_json + bumps session cost on cost-change
  - listProjects aggregation across agents + sessions
  - FTS5 match with snippet markers
  - FTS sanitizer survives `"NEEDLE" AND OR -` user input
  - empty / whitespace queries return `[]`
  - tool_call enrich path
  - prune deletes old events + their session aggregates
  - **bench: 10k events in ~430ms** (target was <2000ms)
- [x] `npm run build` succeeds (no new web bundle changes — store is server-side)
- [ ] Manual smoke: run `agentwatch` against the maintainer's home, confirm `~/.agentwatch/events.db` populates and `agentwatch prune --older-than-days 30` works.

Closes [AUR-263](https://linear.app/auraqu/issue/AUR-263/v01-sqlite-event-store-with-fts5-replace-4mb-rolling-buffer).