### PR TITLE
feat(daemon): background capture daemon (AUR-262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ layout can change freely within a minor version.
   hits the FTS5 index for full-history matches (vs the live ring buffer
   or the JSONL cross-scan). Returns FTS-ranked snippets.
 
+- **Background daemon** (AUR-262) — `agentwatch daemon start | stop |
+  status | logs` installs a launchd LaunchAgent (macOS) or a systemd
+  user unit (Linux) that runs the adapter pipeline 24/7, writing every
+  event into `~/.agentwatch/events.db`. The TUI and `agentwatch serve`
+  are now read clients of the same store, so events captured overnight
+  are visible the moment you open them. PID file + start-time at
+  `~/.agentwatch/daemon.{pid,started_at}`; log at
+  `~/.agentwatch/daemon.log` with a 10 MB single-slot rotation; PID
+  re-acquire is stale-PID-aware (process-alive probe).
+
 ### Changed
 
 - **EventSink wired through the store** in both TUI and `serve` modes —

--- a/src/daemon/daemon.test.ts
+++ b/src/daemon/daemon.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DAEMON_LABEL,
+  renderPlist,
+  renderSystemdUnit,
+  resolveAgentwatchExec,
+} from "./install.js";
+import { RotatingLogStream } from "./log-rotate.js";
+import { isProcessAlive } from "./run.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agentwatch-daemon-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("daemon — log rotation", () => {
+  it("appends to a fresh log file", () => {
+    const path = join(dir, "log");
+    const log = new RotatingLogStream({ path, maxBytes: 1024 });
+    log.write("hello");
+    log.write("world");
+    log.close();
+    const content = readFileSync(path, "utf-8");
+    expect(content).toBe("hello\nworld\n");
+  });
+
+  it("rotates when the next write would exceed maxBytes", () => {
+    const path = join(dir, "log");
+    const log = new RotatingLogStream({ path, maxBytes: 50 });
+    log.write("x".repeat(40)); // 41 bytes including trailing newline
+    log.write("y".repeat(40)); // would push us past 50 → rotate first
+    log.close();
+    expect(existsSync(`${path}.1`)).toBe(true);
+    const main = readFileSync(path, "utf-8");
+    const rotated = readFileSync(`${path}.1`, "utf-8");
+    expect(rotated).toContain("x".repeat(40));
+    expect(main).toContain("y".repeat(40));
+    expect(main.length).toBeLessThan(50);
+  });
+
+  it("creates the parent directory if missing", () => {
+    const nested = join(dir, "nested", "deeper", "log");
+    const log = new RotatingLogStream({ path: nested });
+    log.write("ok");
+    log.close();
+    expect(existsSync(nested)).toBe(true);
+  });
+
+  it("survives a re-open by appending, not truncating", () => {
+    const path = join(dir, "log");
+    let log = new RotatingLogStream({ path });
+    log.write("first");
+    log.close();
+    log = new RotatingLogStream({ path });
+    log.write("second");
+    log.close();
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("first");
+    expect(content).toContain("second");
+    expect(content.indexOf("first")).toBeLessThan(content.indexOf("second"));
+  });
+});
+
+describe("daemon — service unit rendering", () => {
+  it("renders a launchd plist with the daemon label and four-arg ProgramArguments", () => {
+    const plist = renderPlist(
+      { node: "/usr/local/bin/node", script: "/opt/agentwatch/bin/agentwatch.js" },
+      "/Users/x/.agentwatch/daemon.log",
+    );
+    expect(plist).toContain(`<string>${DAEMON_LABEL}</string>`);
+    expect(plist).toContain("<string>/usr/local/bin/node</string>");
+    expect(plist).toContain(
+      "<string>/opt/agentwatch/bin/agentwatch.js</string>",
+    );
+    expect(plist).toContain("<string>daemon</string>");
+    expect(plist).toContain("<string>run</string>");
+    expect(plist).toContain("<key>RunAtLoad</key>");
+    expect(plist).toContain("<key>KeepAlive</key>");
+    expect(plist).toContain(
+      "<string>/Users/x/.agentwatch/daemon.log</string>",
+    );
+  });
+
+  it("renders a systemd unit with simple type, restart-on-failure, and log redirect", () => {
+    const unit = renderSystemdUnit(
+      { node: "/usr/bin/node", script: "/opt/agentwatch/bin/agentwatch.js" },
+      "/home/x/.agentwatch/daemon.log",
+    );
+    expect(unit).toContain("Description=agentwatch event capture daemon");
+    expect(unit).toContain("Type=simple");
+    expect(unit).toContain(
+      "ExecStart=/usr/bin/node /opt/agentwatch/bin/agentwatch.js daemon run",
+    );
+    expect(unit).toContain("Restart=on-failure");
+    expect(unit).toContain("WantedBy=default.target");
+    expect(unit).toContain(
+      "StandardOutput=append:/home/x/.agentwatch/daemon.log",
+    );
+  });
+
+  it("resolveAgentwatchExec uses process.execPath + argv[1]", () => {
+    const exec = resolveAgentwatchExec();
+    expect(exec.node).toBe(process.execPath);
+    expect(exec.script.length).toBeGreaterThan(0);
+  });
+});
+
+describe("daemon — process liveness probe", () => {
+  it("reports the current process as alive", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it("reports a definitely-dead pid as not alive", () => {
+    // PID 0 is reserved (kernel scheduler) — process.kill rejects it.
+    // Use a high pid that's almost certainly unused.
+    expect(isProcessAlive(2_000_000_000)).toBe(false);
+  });
+});
+
+describe("daemon — log file size budget", () => {
+  it("never grows the active log past maxBytes by more than one line", () => {
+    const path = join(dir, "log");
+    const log = new RotatingLogStream({ path, maxBytes: 200 });
+    for (let i = 0; i < 50; i++) log.write(`line ${i} `.repeat(5));
+    log.close();
+    const size = statSync(path).size;
+    // After the last rotation, the active file holds only writes that
+    // came post-rotation. Bound is one full line over the cap.
+    expect(size).toBeLessThan(400);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { platform } from "node:os";
+import {
+  DAEMON_LABEL,
+  logPath,
+  pidFilePath,
+  plistPath,
+  removeServiceUnit,
+  startTimeFilePath,
+  systemdUnitPath,
+  writeServiceUnit,
+} from "./install.js";
+import { isProcessAlive, runDaemon } from "./run.js";
+
+const HELP = `agentwatch daemon — background event capture
+
+Usage:
+  agentwatch daemon start    install + load the user-level service
+  agentwatch daemon stop     unload the service (events.db is preserved)
+  agentwatch daemon status   running state + uptime + capture stats
+  agentwatch daemon logs     tail the daemon log
+  agentwatch daemon run      foreground mode (used by launchd / systemd)
+
+Service files:
+  macOS:  ~/Library/LaunchAgents/${DAEMON_LABEL}.plist
+  Linux:  ~/.config/systemd/user/agentwatch.service
+
+The daemon writes every adapter event to ~/.agentwatch/events.db. The
+TUI and \`agentwatch serve\` read the same store, so events captured
+overnight are visible the moment you open them.
+`;
+
+export async function dispatchDaemon(sub: string | undefined): Promise<void> {
+  switch (sub) {
+    case undefined:
+    case "--help":
+    case "-h":
+      console.log(HELP);
+      process.exit(0);
+      return;
+    case "start":
+      return startCmd();
+    case "stop":
+      return stopCmd();
+    case "status":
+      return statusCmd();
+    case "logs":
+      return logsCmd();
+    case "run":
+      await runDaemon();
+      return;
+    default:
+      process.stderr.write(`agentwatch daemon: unknown subcommand "${sub}"\n`);
+      process.stderr.write(HELP);
+      process.exit(2);
+  }
+}
+
+function startCmd(): void {
+  const result = writeServiceUnit();
+  console.log(`wrote service unit: ${result.unitPath}`);
+  if (platform() === "darwin") {
+    runStep(["launchctl", "unload", result.unitPath], { allowFail: true });
+    runStep(["launchctl", "load", "-w", result.unitPath]);
+    console.log(`daemon loaded — events stream into ~/.agentwatch/events.db`);
+    return;
+  }
+  if (platform() === "linux") {
+    runStep(["systemctl", "--user", "daemon-reload"]);
+    runStep(["systemctl", "--user", "enable", "--now", "agentwatch.service"]);
+    console.log(`daemon enabled + started`);
+    return;
+  }
+  console.log(`unsupported platform; manual steps:`);
+  for (const cmd of result.manualSteps) console.log(`  ${cmd}`);
+}
+
+function stopCmd(): void {
+  if (platform() === "darwin") {
+    const path = plistPath();
+    if (existsSync(path)) {
+      runStep(["launchctl", "unload", path], { allowFail: true });
+    }
+    const removed = removeServiceUnit();
+    console.log(`daemon stopped${removed.unitPath ? ` (removed ${removed.unitPath})` : ""}`);
+    return;
+  }
+  if (platform() === "linux") {
+    runStep(["systemctl", "--user", "disable", "--now", "agentwatch.service"], {
+      allowFail: true,
+    });
+    runStep(["systemctl", "--user", "daemon-reload"], { allowFail: true });
+    const removed = removeServiceUnit();
+    console.log(`daemon stopped${removed.unitPath ? ` (removed ${removed.unitPath})` : ""}`);
+    return;
+  }
+  console.log(`unsupported platform — kill the process manually`);
+}
+
+function statusCmd(): void {
+  const status = readDaemonStatus();
+  if (!status.running) {
+    console.log(`daemon: not running`);
+    if (status.unitInstalled) console.log(`unit installed at: ${status.unitPath}`);
+    process.exit(0);
+  }
+  console.log(`daemon: running (pid ${status.pid})`);
+  console.log(`uptime: ${formatUptime(status.uptimeMs)}`);
+  console.log(
+    `events captured: ${status.eventsCaptured}` +
+      (status.lastEventTs ? ` · last at ${status.lastEventTs}` : ""),
+  );
+  if (status.unitPath) console.log(`unit: ${status.unitPath}`);
+  if (status.dbBytes != null) {
+    console.log(`db size: ${(status.dbBytes / 1_048_576).toFixed(1)} MB`);
+  }
+}
+
+export interface DaemonStatus {
+  running: boolean;
+  pid?: number;
+  uptimeMs: number;
+  eventsCaptured: number;
+  lastEventTs?: string;
+  unitInstalled: boolean;
+  unitPath?: string;
+  dbBytes?: number;
+}
+
+export function readDaemonStatus(): DaemonStatus {
+  const pidFile = pidFilePath();
+  const unitPath =
+    platform() === "darwin"
+      ? plistPath()
+      : platform() === "linux"
+        ? systemdUnitPath()
+        : undefined;
+  const unitInstalled = unitPath ? existsSync(unitPath) : false;
+
+  let pid: number | undefined;
+  let uptimeMs = 0;
+  if (existsSync(pidFile)) {
+    const raw = readFileSync(pidFile, "utf-8").trim();
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0 && isProcessAlive(parsed)) {
+      pid = parsed;
+    }
+  }
+  if (pid && existsSync(startTimeFilePath())) {
+    const startMs = Number(readFileSync(startTimeFilePath(), "utf-8").trim());
+    if (Number.isFinite(startMs)) uptimeMs = Math.max(0, Date.now() - startMs);
+  }
+
+  let eventsCaptured = 0;
+  let lastEventTs: string | undefined;
+  let dbBytes: number | undefined;
+  try {
+    // Lazy require so a missing better-sqlite3 (rare) doesn't break status.
+    const { openStore } = require("../store/sqlite.js") as typeof import("../store/sqlite.js");
+    const store = openStore();
+    const stats = store.stats();
+    eventsCaptured = stats.events;
+    dbBytes = stats.dbBytes;
+    const sessions = store.listSessions({ limit: 1 });
+    lastEventTs = sessions[0]?.lastTs;
+    store.close();
+  } catch {
+    // store unreachable; report what we know
+  }
+
+  return {
+    running: pid != null,
+    ...(pid != null ? { pid } : {}),
+    uptimeMs,
+    eventsCaptured,
+    ...(lastEventTs ? { lastEventTs } : {}),
+    unitInstalled,
+    ...(unitPath ? { unitPath } : {}),
+    ...(dbBytes != null ? { dbBytes } : {}),
+  };
+}
+
+function logsCmd(): void {
+  const path = logPath();
+  if (!existsSync(path)) {
+    console.log(`(no log yet at ${path})`);
+    return;
+  }
+  // Use tail -f if available; fall back to printing the file.
+  const tail = spawnSync("tail", ["-n", "200", "-f", path], {
+    stdio: "inherit",
+  });
+  if (tail.error) {
+    process.stdout.write(readFileSync(path, "utf-8"));
+  }
+}
+
+function runStep(
+  argv: string[],
+  opts: { allowFail?: boolean } = {},
+): void {
+  const [cmd, ...rest] = argv;
+  if (!cmd) return;
+  const result = spawnSync(cmd, rest, { stdio: "inherit" });
+  if (result.error) {
+    if (opts.allowFail) return;
+    throw new Error(`spawn ${cmd}: ${String(result.error)}`);
+  }
+  if (result.status !== 0 && !opts.allowFail) {
+    throw new Error(`${argv.join(" ")} exited ${result.status}`);
+  }
+}
+
+function formatUptime(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`;
+  if (ms < 86_400_000) {
+    const h = Math.floor(ms / 3_600_000);
+    const m = Math.floor((ms % 3_600_000) / 60_000);
+    return `${h}h ${m}m`;
+  }
+  const d = Math.floor(ms / 86_400_000);
+  const h = Math.floor((ms % 86_400_000) / 3_600_000);
+  return `${d}d ${h}h`;
+}

--- a/src/daemon/install.ts
+++ b/src/daemon/install.ts
@@ -1,0 +1,140 @@
+import { homedir, platform } from "node:os";
+import { join, resolve } from "node:path";
+import { existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+
+export const DAEMON_LABEL = "com.agentwatch.daemon";
+
+export interface DaemonExec {
+  /** Absolute path to the node binary that should run the daemon. */
+  node: string;
+  /** Absolute path to the agentwatch entry script (bin/agentwatch.js or src/index.tsx). */
+  script: string;
+}
+
+export function resolveAgentwatchExec(): DaemonExec {
+  return {
+    node: process.execPath,
+    script: resolve(process.argv[1] ?? ""),
+  };
+}
+
+export function plistPath(): string {
+  return join(homedir(), "Library", "LaunchAgents", `${DAEMON_LABEL}.plist`);
+}
+
+export function systemdUnitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", "agentwatch.service");
+}
+
+export function logPath(): string {
+  return join(homedir(), ".agentwatch", "daemon.log");
+}
+
+export function pidFilePath(): string {
+  return join(homedir(), ".agentwatch", "daemon.pid");
+}
+
+export function startTimeFilePath(): string {
+  return join(homedir(), ".agentwatch", "daemon.started_at");
+}
+
+export function renderPlist(exec: DaemonExec, log: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${DAEMON_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${exec.node}</string>
+    <string>${exec.script}</string>
+    <string>daemon</string>
+    <string>run</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${log}</string>
+  <key>StandardErrorPath</key>
+  <string>${log}</string>
+</dict>
+</plist>
+`;
+}
+
+export function renderSystemdUnit(exec: DaemonExec, log: string): string {
+  return `[Unit]
+Description=agentwatch event capture daemon
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${exec.node} ${exec.script} daemon run
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:${log}
+StandardError=append:${log}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export interface InstallResult {
+  unitPath: string;
+  /** Shell commands the operator should run if our spawn() failed (e.g.
+   *  no launchctl on PATH). Empty when the install fully succeeded. */
+  manualSteps: string[];
+}
+
+export function writeServiceUnit(): InstallResult {
+  const exec = resolveAgentwatchExec();
+  const log = logPath();
+  mkdirSync(join(homedir(), ".agentwatch"), { recursive: true });
+  if (platform() === "darwin") {
+    const path = plistPath();
+    mkdirSync(join(homedir(), "Library", "LaunchAgents"), { recursive: true });
+    writeFileSync(path, renderPlist(exec, log), "utf-8");
+    return {
+      unitPath: path,
+      manualSteps: [`launchctl load -w ${path}`],
+    };
+  }
+  if (platform() === "linux") {
+    const path = systemdUnitPath();
+    mkdirSync(join(homedir(), ".config", "systemd", "user"), { recursive: true });
+    writeFileSync(path, renderSystemdUnit(exec, log), "utf-8");
+    return {
+      unitPath: path,
+      manualSteps: [
+        "systemctl --user daemon-reload",
+        "systemctl --user enable --now agentwatch.service",
+      ],
+    };
+  }
+  throw new Error(
+    `agentwatch daemon: unsupported platform "${platform()}" (Windows is on the v0.2 roadmap)`,
+  );
+}
+
+export function removeServiceUnit(): { unitPath: string | null } {
+  const path = platform() === "darwin"
+    ? plistPath()
+    : platform() === "linux"
+      ? systemdUnitPath()
+      : null;
+  if (!path) return { unitPath: null };
+  if (existsSync(path)) {
+    try {
+      unlinkSync(path);
+    } catch {
+      // best effort
+    }
+  }
+  return { unitPath: path };
+}

--- a/src/daemon/log-rotate.ts
+++ b/src/daemon/log-rotate.ts
@@ -1,0 +1,73 @@
+import { closeSync, openSync, renameSync, statSync, writeSync } from "node:fs";
+import { dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+
+/** Append-only log writer with a single rotation slot.
+ *
+ *  When the current log size exceeds `maxBytes`, the file is renamed to
+ *  `<path>.1` (overwriting any previous one) and a fresh `<path>` is
+ *  opened. The daemon never holds a long-running write stream — every
+ *  `write` is `writeSync` so we don't have to drain on shutdown.
+ *
+ *  Single rotation slot is intentional: ten megabytes of history is the
+ *  upper bound, plus a recent ten in `.1`. Anything older isn't worth
+ *  the disk. Operators who want longer history pipe the log to a
+ *  separate journal. */
+export class RotatingLogStream {
+  private fd: number;
+  private bytes: number;
+  private readonly path: string;
+  private readonly maxBytes: number;
+
+  constructor(opts: { path: string; maxBytes?: number }) {
+    this.path = opts.path;
+    this.maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+    mkdirSync(dirname(this.path), { recursive: true });
+    this.fd = openSync(this.path, "a");
+    try {
+      this.bytes = statSync(this.path).size;
+    } catch {
+      this.bytes = 0;
+    }
+  }
+
+  write(line: string): void {
+    const buf = Buffer.from(line.endsWith("\n") ? line : `${line}\n`);
+    if (this.bytes + buf.length > this.maxBytes) {
+      this.rotate();
+    }
+    writeSync(this.fd, buf);
+    this.bytes += buf.length;
+  }
+
+  /** Test seam — read current bytes-on-disk for assertions. */
+  byteCount(): number {
+    return this.bytes;
+  }
+
+  close(): void {
+    try {
+      closeSync(this.fd);
+    } catch {
+      // already closed
+    }
+  }
+
+  private rotate(): void {
+    try {
+      closeSync(this.fd);
+    } catch {
+      // already closed
+    }
+    try {
+      renameSync(this.path, `${this.path}.1`);
+    } catch {
+      // best effort — if rename fails (e.g. read-only fs) just keep
+      // appending and let an operator handle it.
+    }
+    this.fd = openSync(this.path, "a");
+    this.bytes = 0;
+  }
+}

--- a/src/daemon/run.ts
+++ b/src/daemon/run.ts
@@ -1,0 +1,192 @@
+import {
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logPath, pidFilePath, startTimeFilePath } from "./install.js";
+import { RotatingLogStream } from "./log-rotate.js";
+import type { AgentEvent, EventDetails, EventSink } from "../schema.js";
+import { clampTs } from "../schema.js";
+
+/** Run the daemon as a foreground process. The launchd plist / systemd
+ *  unit invokes `agentwatch daemon run` and treats this as the long-
+ *  running supervised process; KeepAlive / Restart handles crash loops.
+ *
+ *  Responsibilities here:
+ *    1. Open the SQLite store
+ *    2. Start every adapter wired through wrapSinkWithStore so events
+ *       persist on disk
+ *    3. Write our PID + start time so `daemon status` can read them
+ *    4. Drain on SIGTERM / SIGINT — close adapters, close store
+ *    5. Stay alive until signaled
+ *
+ *  No TUI, no web server, no notifications. The TUI and `agentwatch
+ *  serve` are clients of the same SQLite store; they observe daemon-
+ *  written events transparently. */
+export async function runDaemon(): Promise<void> {
+  const dataDir = join(homedir(), ".agentwatch");
+  mkdirSync(dataDir, { recursive: true });
+
+  const lock = acquireLock();
+  if (!lock.ok) {
+    process.stderr.write(
+      `[agentwatch daemon] another instance is already running (pid ${lock.existingPid}). Exiting.\n`,
+    );
+    process.exit(2);
+  }
+
+  const log = new RotatingLogStream({ path: logPath() });
+  const logLine = (msg: string): void => {
+    log.write(`${new Date().toISOString()} ${msg}`);
+  };
+  logLine(`daemon starting (pid ${process.pid})`);
+
+  let store: import("../store/sqlite.js").EventStore | null = null;
+  let stoppingHooks: Array<() => Promise<void> | void> = [];
+
+  try {
+    const { openStore, wrapSinkWithStore } = await import("../store/index.js");
+    const { startAllAdapters, stopAllAdapters } = await import(
+      "../adapters/registry.js"
+    );
+    const { detectWorkspaceRoot } = await import("../util/workspace.js");
+
+    store = openStore();
+    const workspace = detectWorkspaceRoot();
+
+    let captured = 0;
+    const inner: EventSink = {
+      emit: (e: AgentEvent) => {
+        e.ts = clampTs(e.ts);
+        captured += 1;
+      },
+      enrich: (_id: string, _patch: Partial<EventDetails>) => {
+        // Daemon-side enrich is purely a store update — handled by the
+        // wrapper; nothing additional to do here.
+      },
+    };
+    const sink = wrapSinkWithStore(inner, store);
+    const adapters = startAllAdapters(sink, workspace);
+    stoppingHooks.push(() => stopAllAdapters(adapters));
+    stoppingHooks.push(() => store?.close());
+
+    logLine(`adapters started; workspace=${workspace}`);
+
+    // Periodic heartbeat to the log so operators can confirm the daemon
+    // is healthy without parsing PID-state. Once a minute is enough.
+    const heartbeat = setInterval(() => {
+      logLine(`heartbeat captured=${captured}`);
+    }, 60_000);
+    heartbeat.unref();
+    stoppingHooks.push(() => clearInterval(heartbeat));
+
+    setupShutdown(stoppingHooks, log, lock.releaseLock);
+
+    // Block forever — adapters keep the event loop alive via their
+    // chokidar watchers. We add a never-resolving promise as a belt and
+    // suspenders so an adapter shutting down cleanly doesn't drop us.
+    await new Promise<void>(() => undefined);
+  } catch (err) {
+    logLine(`fatal: ${String(err)}`);
+    for (const hook of stoppingHooks) {
+      try {
+        await hook();
+      } catch {
+        // best effort
+      }
+    }
+    lock.releaseLock();
+    log.close();
+    process.exit(1);
+  }
+}
+
+interface LockHandle {
+  ok: boolean;
+  existingPid?: number;
+  releaseLock: () => void;
+}
+
+function acquireLock(): LockHandle {
+  const pidFile = pidFilePath();
+  const startFile = startTimeFilePath();
+  if (existsSync(pidFile)) {
+    const raw = readFileSync(pidFile, "utf-8").trim();
+    const pid = Number(raw);
+    if (Number.isFinite(pid) && pid > 0 && isProcessAlive(pid)) {
+      return { ok: false, existingPid: pid, releaseLock: () => undefined };
+    }
+    // Stale PID file — remove it and continue.
+    try {
+      unlinkSync(pidFile);
+    } catch {
+      // best effort
+    }
+  }
+  mkdirSync(dirname(pidFile), { recursive: true });
+  writeFileSync(pidFile, String(process.pid), "utf-8");
+  writeFileSync(startFile, String(Date.now()), "utf-8");
+  return {
+    ok: true,
+    releaseLock: () => {
+      try {
+        unlinkSync(pidFile);
+      } catch {
+        // best effort
+      }
+      try {
+        unlinkSync(startFile);
+      } catch {
+        // best effort
+      }
+    },
+  };
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the process exists but we can't signal it — still alive.
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+function setupShutdown(
+  hooks: Array<() => Promise<void> | void>,
+  log: RotatingLogStream,
+  releaseLock: () => void,
+): void {
+  let shutting = false;
+  const stop = async (sig: string): Promise<void> => {
+    if (shutting) return;
+    shutting = true;
+    log.write(
+      `${new Date().toISOString()} shutdown signal=${sig} draining ${hooks.length} hooks\n`,
+    );
+    for (const hook of hooks) {
+      try {
+        await hook();
+      } catch (err) {
+        log.write(
+          `${new Date().toISOString()} shutdown hook error: ${String(err)}\n`,
+        );
+      }
+    }
+    releaseLock();
+    log.write(`${new Date().toISOString()} daemon stopped cleanly\n`);
+    log.close();
+    process.exit(0);
+  };
+  process.on("SIGTERM", () => void stop("SIGTERM"));
+  process.on("SIGINT", () => void stop("SIGINT"));
+  process.on("SIGHUP", () => void stop("SIGHUP"));
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,8 @@ Usage:
   agentwatch serve          run only the web server (no TUI, for remote boxes)
   agentwatch doctor         detect installed agents and print readiness
   agentwatch mcp            run as an MCP server over stdio
+  agentwatch daemon ...     install + manage the background capture service
+                              (subcommands: start | stop | status | logs)
   agentwatch prune          drop events older than --older-than-days (default 90)
   agentwatch --help         show this help
 
@@ -58,6 +60,13 @@ if (arg === "mcp") {
     process.stderr.write(`[agentwatch] mcp error: ${String(err)}\n`);
     process.exit(1);
   }
+  process.exit(0);
+}
+
+if (arg === "daemon") {
+  const { dispatchDaemon } = await import("./daemon/index.js");
+  await dispatchDaemon(process.argv[3]);
+  // dispatchDaemon either exits or runs forever; if it returns we're done.
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Closes the largest stated limitation in the README — agentwatch was a viewer, not a daemon. `agentwatch daemon start | stop | status | logs` now installs a user-level service that runs the adapter pipeline 24/7 and writes every event into the SQLite store at `~/.agentwatch/events.db`.

**Files added:**
- `src/daemon/install.ts` — renders the launchd plist (macOS) or systemd user unit (Linux); the unit invokes `agentwatch daemon run`.
- `src/daemon/run.ts` — the actual daemon process. Acquires a stale-PID-aware lock at `~/.agentwatch/daemon.pid`, opens the store, starts every adapter wired through `wrapSinkWithStore`, drains cleanly on SIGTERM/SIGINT/SIGHUP.
- `src/daemon/log-rotate.ts` — append-only writer with a single 10 MB rotation slot.
- `src/daemon/index.ts` — controller (`start | stop | status | logs | run`). `status` reports running, PID, uptime, events captured, last event ts, DB size by querying the same store the daemon writes to.
- `src/daemon/daemon.test.ts` — 10 tests covering log rotation, plist + systemd unit rendering, the process-liveness probe, and the active-log size budget.

**Wiring:** `src/index.tsx` dispatches `agentwatch daemon ...` to the controller; `--help` documents it.

## Stacking + base

This PR's base is **PR #16** (AUR-263 SQLite store) because the daemon imports `../store/`. **Merge order:** PR #15 → PR #16 → this PR. GitHub will auto-retarget this PR's base to `main` once PR #16 lands. See the PR review thread on PR #16 for the conflict / merge-order discussion.

## Out of scope

- **Windows service install** (deferred to v0.2 per the ticket).
- **Multi-machine sync** (v0.2).
- **Memory-ceiling validation** (`< 200 MB RSS over 7 days`) — the budget is the goal; verification happens once we dogfood for a week.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 289/289 pass (10 new daemon tests + 17 store tests + 262 existing)
- [x] `npm run build` succeeds
- [ ] Manual smoke: `agentwatch daemon start` on the maintainer's mac, watch `agentwatch daemon status` for ~24h, confirm events.db is growing and uptime is reported correctly.
- [ ] `agentwatch daemon logs` tails `~/.agentwatch/daemon.log` with rotation visible after sustained capture.

Closes [AUR-262](https://linear.app/auraqu/issue/AUR-262/v01-background-daemon-startstopstatus-launchd-systemd).