### PR TITLE
feat(classify): per-event activity classifier (AUR-264)

### DIFF
--- a/src/classify/activity.test.ts
+++ b/src/classify/activity.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../schema.js";
+import {
+  ACTIVITY_CATEGORIES,
+  classifyEvent,
+  type ActivityCategory,
+} from "./activity.js";
+import { withClassifier } from "./sink.js";
+
+let id = 0;
+
+function evt(over: Partial<AgentEvent>): AgentEvent {
+  return {
+    id: `e-${++id}`,
+    ts: new Date().toISOString(),
+    agent: over.agent ?? "claude-code",
+    type: over.type ?? "tool_call",
+    riskScore: over.riskScore ?? 1,
+    path: over.path,
+    cmd: over.cmd,
+    tool: over.tool,
+    summary: over.summary,
+    sessionId: over.sessionId,
+    promptId: over.promptId,
+    details: over.details,
+  };
+}
+
+interface Case {
+  name: string;
+  expect: ActivityCategory;
+  event: AgentEvent;
+}
+
+const CASES: Case[] = [
+  // ---- coding ----
+  {
+    name: "writing a TypeScript source file",
+    expect: "coding",
+    event: evt({ type: "file_write", path: "src/api/auth.ts", tool: "Write" }),
+  },
+  {
+    name: "editing a Python source file",
+    expect: "coding",
+    event: evt({ type: "file_change", path: "app/handlers/login.py" }),
+  },
+  {
+    name: "MultiEdit on a Go file",
+    expect: "coding",
+    event: evt({ type: "file_write", path: "internal/server/routes.go", tool: "MultiEdit" }),
+  },
+  {
+    name: "git commit shell exec",
+    expect: "coding",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "git commit -m feat: add login" }),
+  },
+
+  // ---- testing ----
+  {
+    name: "writing a vitest test file",
+    expect: "testing",
+    event: evt({ type: "file_write", path: "src/api/auth.test.ts", tool: "Write" }),
+  },
+  {
+    name: "writing a pytest test under tests/",
+    expect: "testing",
+    event: evt({ type: "file_write", path: "tests/test_login.py" }),
+  },
+  {
+    name: "running npm test",
+    expect: "testing",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "npm test" }),
+  },
+  {
+    name: "running pytest",
+    expect: "testing",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "pytest -k login" }),
+  },
+
+  // ---- docs ----
+  {
+    name: "editing a markdown doc",
+    expect: "docs",
+    event: evt({ type: "file_write", path: "docs/features/api.md" }),
+  },
+  {
+    name: "editing the README",
+    expect: "docs",
+    event: evt({ type: "file_write", path: "README.md" }),
+  },
+  {
+    name: "editing CHANGELOG",
+    expect: "docs",
+    event: evt({ type: "file_write", path: "CHANGELOG.md" }),
+  },
+
+  // ---- config ----
+  {
+    name: "editing tsconfig.json",
+    expect: "config",
+    event: evt({ type: "file_write", path: "tsconfig.json" }),
+  },
+  {
+    name: "editing a yaml config",
+    expect: "config",
+    event: evt({ type: "file_write", path: "k8s/deployment.yaml" }),
+  },
+  {
+    name: "editing package.json",
+    expect: "config",
+    event: evt({ type: "file_write", path: "package.json" }),
+  },
+
+  // ---- debugging ----
+  {
+    name: "prompt mentioning a stack trace",
+    expect: "debugging",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "I'm getting a stack trace when I call /login — can you fix this bug?" },
+    }),
+  },
+  {
+    name: "shell exec with tool error",
+    expect: "debugging",
+    event: evt({
+      type: "shell_exec",
+      tool: "Bash",
+      cmd: "npm run build",
+      details: { toolError: true },
+    }),
+  },
+
+  // ---- refactor ----
+  {
+    name: "prompt asking to refactor",
+    expect: "refactor",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "please refactor this file to extract the validation logic into its own module" },
+    }),
+  },
+  {
+    name: "prompt asking to rename",
+    expect: "refactor",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "rename getUser to fetchUserById and move it to api/user.ts" },
+    }),
+  },
+
+  // ---- exploration ----
+  {
+    name: "Grep tool call",
+    expect: "exploration",
+    event: evt({ type: "tool_call", tool: "Grep" }),
+  },
+  {
+    name: "reading a non-config source file",
+    expect: "exploration",
+    event: evt({ type: "file_read", path: "src/util/cost.ts" }),
+  },
+
+  // ---- research ----
+  {
+    name: "WebFetch tool call",
+    expect: "research",
+    event: evt({ type: "tool_call", tool: "WebFetch" }),
+  },
+  {
+    name: "WebSearch tool call",
+    expect: "research",
+    event: evt({ type: "tool_call", tool: "WebSearch" }),
+  },
+
+  // ---- review ----
+  {
+    name: "git diff shell exec",
+    expect: "review",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "git diff main" }),
+  },
+  {
+    name: "prompt asking to audit",
+    expect: "review",
+    event: evt({
+      type: "prompt",
+      details: { fullText: "please audit this file for SQL injection vulnerabilities" },
+    }),
+  },
+
+  // ---- devops ----
+  {
+    name: "kubectl shell exec",
+    expect: "devops",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "kubectl get pods -n prod" }),
+  },
+  {
+    name: "docker shell exec",
+    expect: "devops",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "docker compose up -d" }),
+  },
+  {
+    name: "terraform shell exec",
+    expect: "devops",
+    event: evt({ type: "shell_exec", tool: "Bash", cmd: "terraform apply" }),
+  },
+
+  // ---- planning ----
+  {
+    name: "long thinking block",
+    expect: "planning",
+    event: evt({
+      type: "response",
+      details: {
+        thinking: "Let me think through this carefully. ".repeat(80),
+      },
+    }),
+  },
+  {
+    name: "compaction event",
+    expect: "planning",
+    event: evt({ type: "compaction" }),
+  },
+
+  // ---- chat ----
+  {
+    name: "session_start",
+    expect: "chat",
+    event: evt({ type: "session_start" }),
+  },
+  {
+    name: "empty assistant turn",
+    expect: "chat",
+    event: evt({
+      type: "response",
+      details: { fullText: "Sure, here you go." },
+    }),
+  },
+];
+
+describe("classifier — synthetic case dataset", () => {
+  for (const c of CASES) {
+    it(c.name, () => {
+      expect(classifyEvent(c.event)).toBe(c.expect);
+    });
+  }
+
+  it("hits at least 75% top-1 agreement on the synthetic dataset", () => {
+    let matches = 0;
+    for (const c of CASES) {
+      if (classifyEvent(c.event) === c.expect) matches += 1;
+    }
+    const ratio = matches / CASES.length;
+    expect(ratio).toBeGreaterThanOrEqual(0.75);
+  });
+
+  it("returns one of the declared categories for any non-empty input", () => {
+    const valid = new Set<string>(ACTIVITY_CATEGORIES);
+    for (const c of CASES) {
+      expect(valid.has(classifyEvent(c.event))).toBe(true);
+    }
+  });
+});
+
+describe("classifier — withClassifier sink wrapper", () => {
+  it("attaches details.category to events that don't already have one", () => {
+    const captured: AgentEvent[] = [];
+    const inner = {
+      emit: (e: AgentEvent) => captured.push(e),
+      enrich: () => undefined,
+    };
+    const wrapped = withClassifier(inner);
+    wrapped.emit(
+      evt({ type: "file_write", path: "src/api.ts", tool: "Write" }),
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.details?.category).toBe("coding");
+  });
+
+  it("doesn't overwrite a category an upstream sink already set", () => {
+    const captured: AgentEvent[] = [];
+    const inner = {
+      emit: (e: AgentEvent) => captured.push(e),
+      enrich: () => undefined,
+    };
+    const wrapped = withClassifier(inner);
+    wrapped.emit(
+      evt({
+        type: "file_write",
+        path: "src/api.ts",
+        details: { category: "review" },
+      }),
+    );
+    expect(captured[0]?.details?.category).toBe("review");
+  });
+
+  it("forwards enrich unchanged", () => {
+    const enriches: Array<{ id: string; patch: object }> = [];
+    const inner = {
+      emit: () => undefined,
+      enrich: (id: string, patch: object) => enriches.push({ id, patch }),
+    };
+    const wrapped = withClassifier(inner);
+    wrapped.enrich("e-1", { toolResult: "ok" });
+    expect(enriches).toEqual([{ id: "e-1", patch: { toolResult: "ok" } }]);
+  });
+});

--- a/src/classify/activity.ts
+++ b/src/classify/activity.ts
@@ -1,0 +1,196 @@
+import type { AgentEvent } from "../schema.js";
+
+export type ActivityCategory =
+  | "coding"
+  | "debugging"
+  | "exploration"
+  | "planning"
+  | "refactor"
+  | "testing"
+  | "docs"
+  | "chat"
+  | "config"
+  | "review"
+  | "devops"
+  | "research";
+
+export const ACTIVITY_CATEGORIES: ActivityCategory[] = [
+  "coding",
+  "debugging",
+  "exploration",
+  "planning",
+  "refactor",
+  "testing",
+  "docs",
+  "chat",
+  "config",
+  "review",
+  "devops",
+  "research",
+];
+
+/** Classify a single event into one of the activity categories.
+ *
+ *  This is a heuristic ladder: each rule contributes a weighted score
+ *  for one category, and the highest-scoring category wins. The
+ *  categories are deliberately broad (matching CodeBurn's 13 buckets)
+ *  so the resulting pie chart answers "where is my spend going?" not
+ *  "what exact thing is the agent doing?"
+ *
+ *  Heuristics are derived from observable signals only — tool name,
+ *  file extension, command verb, and a small keyword set on prompt /
+ *  response text. No ML dependency. When no rule fires we fall through
+ *  to `chat` (the catch-all bucket for assistant turns with no tool use). */
+export function classifyEvent(event: AgentEvent): ActivityCategory {
+  const scores = scoreEvent(event);
+  let winner: ActivityCategory = "chat";
+  let max = 0;
+  for (const cat of ACTIVITY_CATEGORIES) {
+    const s = scores[cat] ?? 0;
+    if (s > max) {
+      max = s;
+      winner = cat;
+    }
+  }
+  return winner;
+}
+
+export function scoreEvent(
+  event: AgentEvent,
+): Partial<Record<ActivityCategory, number>> {
+  const scores: Partial<Record<ActivityCategory, number>> = {};
+  const add = (cat: ActivityCategory, n: number): void => {
+    scores[cat] = (scores[cat] ?? 0) + n;
+  };
+
+  const path = (event.path ?? "").toLowerCase();
+  const cmd = (event.cmd ?? "").toLowerCase();
+  const tool = (event.tool ?? "").toLowerCase();
+  const summary = (event.summary ?? "").toLowerCase();
+  const fullText = (event.details?.fullText ?? "").toLowerCase();
+  const thinking = (event.details?.thinking ?? "").toLowerCase();
+  const toolError = event.details?.toolError === true;
+  const text = `${summary} ${fullText} ${thinking}`;
+
+  // ---- File-extension signals ----
+  if (event.type === "file_write" || event.type === "file_change") {
+    if (isTestPath(path)) add("testing", 8);
+    else if (isDocPath(path)) add("docs", 8);
+    else if (isConfigPath(path)) add("config", 8);
+    else add("coding", 7);
+  } else if (event.type === "file_read") {
+    if (isTestPath(path)) add("testing", 3);
+    else if (isDocPath(path)) add("docs", 3);
+    else if (isConfigPath(path)) add("config", 3);
+    else add("exploration", 4);
+  }
+
+  // ---- Tool signals ----
+  if (tool === "edit" || tool === "multiedit" || tool === "write") {
+    if (isTestPath(path)) add("testing", 4);
+    else if (isDocPath(path)) add("docs", 4);
+    else add("coding", 4);
+  }
+  if (tool === "read") add("exploration", 1);
+  if (tool === "grep" || tool === "glob") add("exploration", 3);
+  if (tool === "webfetch" || tool === "websearch") add("research", 6);
+  if (tool === "task") add("planning", 2);
+
+  // ---- Shell-command signals ----
+  if (event.type === "shell_exec" || tool === "bash") {
+    if (/(\bnpm test\b|\bvitest\b|\bjest\b|\bpytest\b|\bmocha\b|\bpnpm test\b|\bcargo test\b|\bgo test\b)/.test(cmd)) {
+      add("testing", 8);
+    }
+    if (/(\bdocker\b|\bkubectl\b|\bterraform\b|\bansible\b|\bhelm\b|\baws\b|\bgcloud\b|\bsystemctl\b)/.test(cmd)) {
+      add("devops", 7);
+    }
+    if (/\bgit\s+(diff|status|log|blame|show)/.test(cmd)) add("review", 4);
+    if (/\bgit\s+(add|commit|push|merge|rebase|checkout)/.test(cmd)) add("coding", 3);
+    if (/\b(eslint|prettier|tsc|typecheck|lint|mypy|pyright)\b/.test(cmd)) add("review", 3);
+    if (/\b(make|cargo|npm run|pnpm run|yarn run|bun run)\b/.test(cmd)) add("coding", 2);
+    if (toolError) add("debugging", 4);
+  }
+
+  // ---- Text signals (prompt + response + thinking content) ----
+  if (event.type === "prompt" || event.type === "response") {
+    if (/\b(refactor|rename|extract|inline|move|reorganize|restructure)\b/.test(text)) {
+      add("refactor", 6);
+    }
+    if (/\b(error|exception|stack[- ]?trace|traceback|fail(?:ed|ing|ure)?|broken|bug|crash|throws?|undefined is not|cannot read prop|nullpointer)\b/.test(text)) {
+      add("debugging", 5);
+    }
+    if (/\b(test(?:s|ing)?|assert(?:ion)?s?|spec(?:s|tests)?|coverage|mock(?:s|ing)?)\b/.test(text)) {
+      add("testing", 3);
+    }
+    if (/\b(review|audit|check|look at|inspect|verify|critique)\b/.test(text)) {
+      add("review", 4);
+    }
+    if (/\b(plan|approach|step\s\d|first[, ]|then\b|finally\b|let\s+me\s+think|let\s+us|design)\b/.test(text)) {
+      add("planning", 2);
+    }
+    if (/\b(deploy|deployment|release|rollout|pipeline|ci\/cd|production|staging|prod\b)\b/.test(text)) {
+      add("devops", 3);
+    }
+    if (/\b(document(?:ation)?|readme|changelog|docs?\b|comment[s]?|jsdoc|tsdoc|docstring)\b/.test(text)) {
+      add("docs", 3);
+    }
+    if (/\b(config(?:ure|uration)?|settings|environment|env\s+var|toml|yaml|yml|tsconfig|package\.json)\b/.test(text)) {
+      add("config", 3);
+    }
+    if (/\b(research|read about|articles?|paper(s)?|blog\b|reference|literature)\b/.test(text)) {
+      add("research", 3);
+    }
+    if (/\b(what is|how does|how do i|where is|find\b|search\b|locate\b)\b/.test(text)) {
+      add("exploration", 2);
+    }
+  }
+
+  // ---- Thinking-block weight: long thinking dominates planning ----
+  const thinkingLen = thinking.length;
+  if (thinkingLen > 1500) add("planning", 5);
+  else if (thinkingLen > 300) add("planning", 2);
+
+  // ---- Catch-all so chat wins for empty assistant chatter ----
+  if (event.type === "prompt" || event.type === "response") {
+    if (Object.keys(scores).length === 0) add("chat", 1);
+  }
+
+  // Session-scaffolding events shouldn't bias category weight; classify
+  // them as chat by convention so they don't poison the pie chart.
+  if (event.type === "session_start" || event.type === "session_end") {
+    return { chat: 1 };
+  }
+  if (event.type === "compaction") {
+    return { planning: 1 };
+  }
+  if (event.type === "parse_error") {
+    return { chat: 0 };
+  }
+
+  return scores;
+}
+
+function isTestPath(p: string): boolean {
+  if (!p) return false;
+  return /(^|\/)(tests?|__tests__|spec)\//.test(p) || /\.(test|spec)\.[a-z0-9]+$/.test(p);
+}
+
+function isDocPath(p: string): boolean {
+  if (!p) return false;
+  if (/\.(md|mdx|rst|adoc|txt)$/.test(p)) return true;
+  if (/(^|\/)(docs?|guides?|examples?)\//.test(p)) return true;
+  if (/(^|\/)(readme|changelog|contributing|license|security|code_of_conduct)/i.test(p)) {
+    return true;
+  }
+  return false;
+}
+
+function isConfigPath(p: string): boolean {
+  if (!p) return false;
+  if (/\.(json|ya?ml|toml|ini|env|config\.[jt]s|cjs|mjs)$/.test(p)) return true;
+  if (/(^|\/)(\.env(?:\..*)?|tsconfig|tsup\.config|vitest\.config|vite\.config|jest\.config|babel\.config|webpack\.config|rollup\.config|prettier\.config|eslint\.config|tailwind\.config|postcss\.config)$/i.test(p)) {
+    return true;
+  }
+  if (/(^|\/)package\.json$/i.test(p)) return true;
+  return false;
+}

--- a/src/classify/index.ts
+++ b/src/classify/index.ts
@@ -1,0 +1,7 @@
+export {
+  classifyEvent,
+  scoreEvent,
+  ACTIVITY_CATEGORIES,
+  type ActivityCategory,
+} from "./activity.js";
+export { withClassifier } from "./sink.js";

--- a/src/classify/sink.ts
+++ b/src/classify/sink.ts
@@ -1,0 +1,24 @@
+import type { AgentEvent, EventDetails, EventSink } from "../schema.js";
+import { classifyEvent } from "./activity.js";
+
+/** Wraps an EventSink so every emitted event has `details.category`
+ *  attached before it propagates further. Idempotent — if a category
+ *  is already present we leave it (some upstream might have set a
+ *  better one).
+ *
+ *  Place this BEFORE the store wrapper so the categorization is
+ *  persisted alongside the event. */
+export function withClassifier(inner: EventSink): EventSink {
+  return {
+    emit: (event: AgentEvent) => {
+      if (!event.details) event.details = {};
+      if (!event.details.category) {
+        event.details.category = classifyEvent(event);
+      }
+      inner.emit(event);
+    },
+    enrich: (eventId: string, patch: Partial<EventDetails>) => {
+      inner.enrich(eventId, patch);
+    },
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -152,7 +152,9 @@ if (arg === "serve") {
       server.broadcaster.emitEnrich(eventId, patch);
     },
   };
-  const sink = store ? wrapSinkWithStore(innerSink, store) : innerSink;
+  const { withClassifier } = await import("./classify/index.js");
+  const persistSink = store ? wrapSinkWithStore(innerSink, store) : innerSink;
+  const sink = withClassifier(persistSink);
   const adapters = startAllAdapters(sink, workspace);
   onShutdown(() => stopAllAdapters(adapters));
   onShutdown(() => server.stop());

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -103,6 +103,22 @@ export interface EventDetails {
   parseErrorCount?: number;
   /** Truncated preview of the most recent unparseable line. */
   parseErrorSample?: string;
+  /** Activity category — one of ACTIVITY_CATEGORIES. Heuristically assigned
+   *  on emit by the classify wrapper (AUR-264). Used by the per-session
+   *  and per-project activity views to answer "where is my spend going?". */
+  category?:
+    | "coding"
+    | "debugging"
+    | "exploration"
+    | "planning"
+    | "refactor"
+    | "testing"
+    | "docs"
+    | "chat"
+    | "config"
+    | "review"
+    | "devops"
+    | "research";
 }
 
 /** Sink passed to adapters. Adapters emit new events and may later

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { registerAgentRoutes } from "./routes/agents.js";
 import { registerPermissionRoutes } from "./routes/permissions.js";
 import { registerCronRoutes } from "./routes/cron.js";
 import { registerSearchRoutes } from "./routes/search.js";
+import { registerActivityRoutes } from "./routes/activity.js";
 import type { EventStore } from "../store/sqlite.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerTrendsRoutes } from "./routes/trends.js";
@@ -154,6 +155,7 @@ export async function startServer(opts: StartServerOptions): Promise<ServerHandl
   registerPermissionRoutes(app);
   registerCronRoutes(app, events);
   registerSearchRoutes(app, events, opts.store);
+  registerActivityRoutes(app, opts.store);
   registerConfigRoutes(app);
   registerTrendsRoutes(app, events);
   registerDiffRoutes(app, events);

--- a/src/server/routes/activity.ts
+++ b/src/server/routes/activity.ts
@@ -1,0 +1,29 @@
+import type { FastifyInstance } from "fastify";
+import type { EventStore } from "../../store/sqlite.js";
+
+/** Per-category activity rollups for a session or project. Routes return
+ *  empty arrays when no store is attached or no matching data exists —
+ *  the UI is responsible for showing an empty-state instead of a 404,
+ *  because "this session has zero events of any category" is meaningful. */
+export function registerActivityRoutes(
+  app: FastifyInstance,
+  store?: EventStore,
+): void {
+  app.get<{ Params: { id: string } }>(
+    "/api/sessions/:id/activity",
+    async (req) => {
+      const id = decodeURIComponent(req.params.id);
+      if (!store) return { sessionId: id, buckets: [] };
+      return { sessionId: id, buckets: store.activityBySession(id) };
+    },
+  );
+
+  app.get<{ Params: { name: string } }>(
+    "/api/projects/:name/activity",
+    async (req) => {
+      const name = decodeURIComponent(req.params.name);
+      if (!store) return { project: name, buckets: [] };
+      return { project: name, buckets: store.activityByProject(name) };
+    },
+  );
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,5 +8,6 @@ export {
   type ListSessionsOptions,
   type PruneResult,
   type StoreStats,
+  type ActivityBucket,
 } from "./sqlite.js";
 export { wrapSinkWithStore } from "./wire.js";

--- a/src/store/sqlite.test.ts
+++ b/src/store/sqlite.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 
 describe("sqlite store — schema + lifecycle", () => {
   it("initializes schema_version to current", () => {
-    expect(store.stats().schemaVersion).toBe(1);
+    expect(store.stats().schemaVersion).toBeGreaterThanOrEqual(1);
   });
 
   it("re-opening an existing db is idempotent (CREATE IF NOT EXISTS)", () => {
@@ -309,6 +309,80 @@ describe("sqlite store — prune", () => {
     const sessions = store.listSessions().map((s) => s.sessionId);
     expect(sessions).not.toContain("old-s");
     expect(sessions).toContain("new-s");
+  });
+});
+
+describe("sqlite store — activity rollups (v2)", () => {
+  it("activityBySession buckets events by category with counts and cost", () => {
+    store.insertMany([
+      makeEvent({
+        id: "a1",
+        sessionId: "act-s",
+        details: { category: "coding", cost: 0.10 },
+      }),
+      makeEvent({
+        id: "a2",
+        sessionId: "act-s",
+        details: { category: "coding", cost: 0.05 },
+      }),
+      makeEvent({
+        id: "a3",
+        sessionId: "act-s",
+        details: { category: "testing", cost: 0.02 },
+      }),
+      makeEvent({
+        id: "a4",
+        sessionId: "other-s",
+        details: { category: "coding", cost: 0.99 },
+      }),
+    ]);
+    const buckets = store.activityBySession("act-s");
+    const coding = buckets.find((b) => b.category === "coding");
+    const testing = buckets.find((b) => b.category === "testing");
+    expect(coding?.eventCount).toBe(2);
+    expect(coding?.costUsd).toBeCloseTo(0.15);
+    expect(testing?.eventCount).toBe(1);
+    expect(buckets[0]?.category).toBe("coding"); // sorted by count
+  });
+
+  it("activityByProject aggregates across sessions of one project", () => {
+    store.insertMany([
+      makeEvent({
+        id: "p1",
+        sessionId: "s1",
+        summary: "[bpi] do work",
+        details: { category: "coding", cost: 0.10 },
+      }),
+      makeEvent({
+        id: "p2",
+        sessionId: "s2",
+        summary: "[bpi] more work",
+        details: { category: "coding", cost: 0.20 },
+      }),
+      makeEvent({
+        id: "p3",
+        sessionId: "s3",
+        summary: "[other] not us",
+        details: { category: "coding", cost: 0.99 },
+      }),
+    ]);
+    const buckets = store.activityByProject("bpi");
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]?.category).toBe("coding");
+    expect(buckets[0]?.eventCount).toBe(2);
+    expect(buckets[0]?.costUsd).toBeCloseTo(0.30);
+  });
+
+  it("uses 'chat' as the bucket label for events without a category", () => {
+    store.insert(
+      makeEvent({
+        id: "u1",
+        sessionId: "u-sess",
+        details: { cost: 0.01 },
+      }),
+    );
+    const buckets = store.activityBySession("u-sess");
+    expect(buckets[0]?.category).toBe("chat");
   });
 });
 

--- a/src/store/sqlite.ts
+++ b/src/store/sqlite.ts
@@ -52,6 +52,12 @@ export interface StoreStats {
   schemaVersion: number;
 }
 
+export interface ActivityBucket {
+  category: string;
+  eventCount: number;
+  costUsd: number;
+}
+
 export interface EventStore {
   insert(event: AgentEvent): void;
   insertMany(events: AgentEvent[]): void;
@@ -62,12 +68,16 @@ export interface EventStore {
   listSessions(opts?: ListSessionsOptions): SessionSummary[];
   listProjects(): ProjectSummary[];
   searchFts(query: string, opts?: { limit?: number }): FtsHit[];
+  /** Per-category event count + cost for a single session. */
+  activityBySession(sessionId: string): ActivityBucket[];
+  /** Per-category event count + cost across every session in a project. */
+  activityByProject(projectName: string): ActivityBucket[];
   prune(opts: { olderThanDays: number }): PruneResult;
   stats(): StoreStats;
   close(): void;
 }
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 export const DEFAULT_DB_PATH = join(homedir(), ".agentwatch", "events.db");
 
@@ -93,10 +103,26 @@ function applyMigrations(db: Database.Database): void {
     .get() as { version: number } | undefined;
   const current = row?.version ?? 0;
   if (current < 1) applyV1(db);
-  // Future versions: if (current < 2) applyV2(db);
+  if (current < 2) applyV2(db);
   db.prepare(
     "INSERT OR REPLACE INTO schema_version (version) VALUES (?)",
   ).run(SCHEMA_VERSION);
+}
+
+function applyV2(db: Database.Database): void {
+  // AUR-264: per-event activity category. ALTER TABLE adds the column;
+  // FTS5 doesn't reference category so the existing triggers stay valid.
+  // Idempotent — duplicate-column on a re-applied migration is swallowed.
+  try {
+    db.exec(`ALTER TABLE events ADD COLUMN category TEXT`);
+  } catch (err) {
+    if (!String(err).includes("duplicate column name")) throw err;
+  }
+  try {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_events_category ON events(category)`);
+  } catch {
+    // best effort
+  }
 }
 
 function applyV1(db: Database.Database): void {
@@ -203,14 +229,14 @@ function buildStore(db: Database.Database): EventStore {
       session_id, prompt_id, risk_score, project, details_json,
       full_text, thinking, tool_input_json, tool_result,
       cost_usd, model, duration_ms, tool_error,
-      sub_agent_id, parent_spawn_id
+      sub_agent_id, parent_spawn_id, category
     )
     VALUES (
       @id, @ts, @agent, @type, @path, @cmd, @tool, @summary,
       @session_id, @prompt_id, @risk_score, @project, @details_json,
       @full_text, @thinking, @tool_input_json, @tool_result,
       @cost_usd, @model, @duration_ms, @tool_error,
-      @sub_agent_id, @parent_spawn_id
+      @sub_agent_id, @parent_spawn_id, @category
     )
   `);
 
@@ -260,6 +286,7 @@ function buildStore(db: Database.Database): EventStore {
       tool_error: d.toolError == null ? null : d.toolError ? 1 : 0,
       sub_agent_id: d.subAgentId ?? null,
       parent_spawn_id: d.parentSpawnId ?? null,
+      category: d.category ?? null,
     };
     const info = insertStmt.run(params);
     if (info.changes > 0 && event.tool) {
@@ -469,6 +496,52 @@ function buildStore(db: Database.Database): EventStore {
         snippet: r.snip,
         rank: r.rank,
       }));
+    },
+    activityBySession(sessionId) {
+      const rows = db
+        .prepare(
+          `SELECT COALESCE(category, 'chat') AS category,
+                  COUNT(*) AS event_count,
+                  COALESCE(SUM(cost_usd), 0) AS cost_total
+           FROM events
+           WHERE session_id = ?
+           GROUP BY COALESCE(category, 'chat')`,
+        )
+        .all(sessionId) as Array<{
+        category: string;
+        event_count: number;
+        cost_total: number;
+      }>;
+      return rows
+        .map((r) => ({
+          category: r.category,
+          eventCount: r.event_count,
+          costUsd: r.cost_total,
+        }))
+        .sort((a, b) => b.eventCount - a.eventCount);
+    },
+    activityByProject(projectName) {
+      const rows = db
+        .prepare(
+          `SELECT COALESCE(category, 'chat') AS category,
+                  COUNT(*) AS event_count,
+                  COALESCE(SUM(cost_usd), 0) AS cost_total
+           FROM events
+           WHERE project = ?
+           GROUP BY COALESCE(category, 'chat')`,
+        )
+        .all(projectName) as Array<{
+        category: string;
+        event_count: number;
+        cost_total: number;
+      }>;
+      return rows
+        .map((r) => ({
+          category: r.category,
+          eventCount: r.event_count,
+          costUsd: r.cost_total,
+        }))
+        .sort((a, b) => b.eventCount - a.eventCount);
     },
     prune({ olderThanDays }) {
       const cutoffMs = Date.now() - olderThanDays * 86_400_000;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -26,6 +26,7 @@ import { startServer, type ServerHandle, addEventToServer } from "../server/inde
 import { openUrl } from "../util/open-url.js";
 import { onShutdown } from "../util/shutdown.js";
 import { openStore, wrapSinkWithStore, type EventStore } from "../store/index.js";
+import { withClassifier } from "../classify/index.js";
 
 /**
  * agentwatch TUI — live log tail.
@@ -158,7 +159,8 @@ export function App() {
         }
       },
     };
-    const finalSink = store ? wrapSinkWithStore(sink, store) : sink;
+    const persistSink = store ? wrapSinkWithStore(sink, store) : sink;
+    const finalSink = withClassifier(persistSink);
     const adapters = startAllAdapters(finalSink, workspace);
     const unregisterShutdown = onShutdown(() => {
       flush();


### PR DESCRIPTION
## Summary

Adds a 12-category activity classifier so we can answer the CodeBurn-viral question *"where is my spend going?"* Categories: `coding`, `debugging`, `exploration`, `planning`, `refactor`, `testing`, `docs`, `chat`, `config`, `review`, `devops`, `research`.

**`src/classify/activity.ts`** — heuristic ladder, no ML dep. Combines:
- File-extension signals: `.test.ts` → `testing`, `.md` / `README` / `CHANGELOG` → `docs`, `package.json` / `tsconfig` / `*.toml` → `config`, source files → `coding`.
- Tool-name signals: `Grep` / `Glob` → `exploration`, `WebFetch` / `WebSearch` → `research`, `Edit` / `MultiEdit` / `Write` → `coding` (or `testing`/`docs` if path matches).
- Shell-command signals: `npm test` / `pytest` / `vitest` → `testing`; `kubectl` / `docker` / `terraform` / `helm` → `devops`; `git diff` / `eslint` / `tsc` → `review`; `git commit` / `git push` → `coding`.
- Prompt/response keyword signals: `refactor` / `rename` / `extract` → `refactor`; `error` / `stack trace` / `bug` → `debugging`; `audit` / `review` / `inspect` → `review`; long `<thinking>` blocks → `planning`.

Empty input falls through to `chat`.

**`src/classify/sink.ts`** — `withClassifier(inner)` wraps an `EventSink` so events arrive at the next stage with `details.category` attached. Idempotent: won't overwrite an already-set category. Wired into both TUI and `serve` mode in front of the store wrapper:

```
adapters → withClassifier → wrapSinkWithStore → innerSink
```

**Schema v2 migration** — `ALTER TABLE events ADD COLUMN category TEXT`, new index `idx_events_category`, store gains `activityBySession(id)` and `activityByProject(name)` that `GROUP BY category` and return `[{ category, eventCount, costUsd }]`. The migration is idempotent (duplicate-column on re-apply is swallowed).

**New API** — `GET /api/sessions/:id/activity`, `GET /api/projects/:name/activity`. Empty arrays when no store / no data.

## Out of scope (deferred to follow-up tickets)

- **React activity views** in the web UI — the API ships now; the stacked-bar / time-series visualization is its own UI ticket.
- **TUI EventDetail category surface** — the category is on `event.details.category`, but the existing detail pane doesn't render it yet.
- **Full 200-turn hand-labelled validation harness** — the ticket called for hand-labelled real-session data; the PR ships a 30-case synthetic dataset that asserts ≥75% top-1 agreement (≥30/30 in practice). The full harness needs a privacy review before we hand-label real sessions; we re-evaluate accuracy on dogfood data after v0.1 ships.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **315/315** pass (36 new classifier tests + 3 new store activity-rollup tests + the existing 276)
- [x] `npm run build` succeeds

## Stacking

Base = PR #16 branch. Merge order: PR #15 → PR #16 → PR #17 (daemon) → this. GitHub will auto-retarget this PR's base to `main` after PR #16 merges. CHANGELOG entry deferred to a release-cut PR to avoid further conflicts.

Closes [AUR-264](https://linear.app/auraqu/issue/AUR-264/v01-activity-classifier-10-categories-per-turn).