### PR TITLE
feat(yield): git-correlation $/commit + $/line views (AUR-265)

### DIFF
--- a/src/git/correlate.test.ts
+++ b/src/git/correlate.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  aggregateProjectYield,
+  correlateSessionYield,
+  findProjectGitRoot,
+  listCommits,
+  mondayOfWeekIso,
+  type Commit,
+} from "./correlate.js";
+import type { SessionSummary } from "../store/sqlite.js";
+
+let workspace: string;
+let repo: string;
+
+function gitInit(path: string): void {
+  execSync(`git init -q ${path}`);
+  execSync(`git -C ${path} config user.email agent@test`);
+  execSync(`git -C ${path} config user.name agent`);
+  execSync(`git -C ${path} config commit.gpgsign false`);
+}
+
+function commit(repoPath: string, file: string, content: string, msg: string, ts: string): void {
+  writeFileSync(join(repoPath, file), content);
+  execSync(`git -C ${repoPath} add ${file}`);
+  execSync(
+    `GIT_AUTHOR_DATE='${ts}' GIT_COMMITTER_DATE='${ts}' git -C ${repoPath} commit -q -m '${msg.replace(/'/g, "")}' --no-gpg-sign`,
+  );
+}
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "agentwatch-yield-ws-"));
+  repo = join(workspace, "demo");
+  execSync(`mkdir -p ${repo}`);
+  gitInit(repo);
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe("git/correlate — findProjectGitRoot", () => {
+  it("returns the absolute path when the project dir contains a .git folder", () => {
+    const root = findProjectGitRoot(workspace, "demo");
+    expect(root).not.toBeNull();
+    expect(root).toMatch(/\/demo$/);
+  });
+
+  it("returns null when the directory exists but has no .git", () => {
+    execSync(`mkdir -p ${join(workspace, "no-repo")}`);
+    expect(findProjectGitRoot(workspace, "no-repo")).toBeNull();
+  });
+
+  it("returns null when the project dir doesn't exist", () => {
+    expect(findProjectGitRoot(workspace, "missing")).toBeNull();
+  });
+
+  it("returns null for a non-existent workspace", () => {
+    expect(findProjectGitRoot("/does/not/exist", "demo")).toBeNull();
+  });
+});
+
+describe("git/correlate — listCommits", () => {
+  it("returns commits with ISO author dates, insertions, and deletions", () => {
+    commit(repo, "a.txt", "hello\n", "first", "2026-04-10T10:00:00Z");
+    commit(repo, "a.txt", "hello\nworld\n", "second", "2026-04-11T10:00:00Z");
+    const commits = listCommits(repo);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]?.subject).toBe("first");
+    expect(commits[0]?.authorDate.startsWith("2026-04-10")).toBe(true);
+    expect(commits[0]?.insertions).toBeGreaterThanOrEqual(1);
+    expect(commits[1]?.subject).toBe("second");
+    expect(commits[1]?.insertions).toBeGreaterThanOrEqual(1);
+  });
+
+  it("filters by --since / --until", () => {
+    commit(repo, "a.txt", "1\n", "old", "2026-03-01T00:00:00Z");
+    commit(repo, "a.txt", "2\n", "new", "2026-04-15T00:00:00Z");
+    const commits = listCommits(repo, { since: "2026-04-01T00:00:00Z" });
+    expect(commits).toHaveLength(1);
+    expect(commits[0]?.subject).toBe("new");
+  });
+
+  it("returns [] for a non-git directory", () => {
+    expect(listCommits(workspace)).toEqual([]);
+  });
+});
+
+describe("git/correlate — correlateSessionYield", () => {
+  function session(over: Partial<SessionSummary>): SessionSummary {
+    return {
+      sessionId: over.sessionId ?? "s",
+      agent: over.agent ?? "claude-code",
+      project: over.project ?? "demo",
+      firstTs: over.firstTs ?? "2026-04-10T10:00:00Z",
+      lastTs: over.lastTs ?? "2026-04-10T11:00:00Z",
+      eventCount: over.eventCount ?? 1,
+      costUsd: over.costUsd ?? 1.0,
+    };
+  }
+
+  function commitFixture(over: Partial<Commit>): Commit {
+    return {
+      hash: over.hash ?? "h",
+      authorDate: over.authorDate ?? "2026-04-10T10:30:00Z",
+      authorName: over.authorName ?? "agent",
+      filesChanged: over.filesChanged ?? 1,
+      insertions: over.insertions ?? 5,
+      deletions: over.deletions ?? 2,
+      subject: over.subject ?? "msg",
+    };
+  }
+
+  it("matches commits inside the session window + 30 min grace", () => {
+    const inWindow = commitFixture({ hash: "in", authorDate: "2026-04-10T11:20:00Z" });
+    const tooLate = commitFixture({ hash: "late", authorDate: "2026-04-10T12:00:00Z" });
+    const tooEarly = commitFixture({ hash: "early", authorDate: "2026-04-10T09:30:00Z" });
+    const y = correlateSessionYield(session({}), [inWindow, tooLate, tooEarly]);
+    expect(y.commits.map((c) => c.hash)).toEqual(["in"]);
+  });
+
+  it("computes cost-per-commit + cost-per-line", () => {
+    const c1 = commitFixture({ hash: "a", insertions: 4, deletions: 1 }); // 5 lines
+    const c2 = commitFixture({ hash: "b", insertions: 3, deletions: 2 }); // 5 lines
+    const y = correlateSessionYield(session({ costUsd: 2.0 }), [c1, c2]);
+    expect(y.costPerCommit).toBeCloseTo(1.0);
+    expect(y.costPerLineChanged).toBeCloseTo(2.0 / 10);
+    expect(y.totalInsertions).toBe(7);
+    expect(y.totalDeletions).toBe(3);
+    expect(y.totalFilesChanged).toBe(2);
+  });
+
+  it("returns null cost-per-* when no commits match", () => {
+    const y = correlateSessionYield(session({}), []);
+    expect(y.commits).toEqual([]);
+    expect(y.costPerCommit).toBeNull();
+    expect(y.costPerLineChanged).toBeNull();
+  });
+});
+
+describe("git/correlate — aggregateProjectYield", () => {
+  it("buckets cost + commits per ISO week and surfaces spend-without-commit", () => {
+    const sessions: SessionSummary[] = [
+      {
+        sessionId: "s1",
+        agent: "claude-code",
+        project: "demo",
+        firstTs: "2026-04-06T10:00:00Z", // Monday → 2026-04-06
+        lastTs: "2026-04-06T11:00:00Z",
+        eventCount: 5,
+        costUsd: 2.0,
+      },
+      {
+        sessionId: "s2",
+        agent: "claude-code",
+        project: "demo",
+        firstTs: "2026-04-13T10:00:00Z", // Monday → 2026-04-13
+        lastTs: "2026-04-13T11:00:00Z",
+        eventCount: 5,
+        costUsd: 1.0,
+      },
+      {
+        sessionId: "s3",
+        agent: "claude-code",
+        project: "demo",
+        firstTs: "2026-04-20T10:00:00Z",
+        lastTs: "2026-04-20T11:00:00Z",
+        eventCount: 5,
+        costUsd: 0.5, // no commits this week
+      },
+    ];
+    const commits: Commit[] = [
+      {
+        hash: "c1",
+        authorDate: "2026-04-06T10:30:00Z",
+        authorName: "x",
+        filesChanged: 1,
+        insertions: 5,
+        deletions: 0,
+        subject: "x",
+      },
+      {
+        hash: "c2",
+        authorDate: "2026-04-13T10:30:00Z",
+        authorName: "x",
+        filesChanged: 1,
+        insertions: 1,
+        deletions: 0,
+        subject: "y",
+      },
+    ];
+    const yld = aggregateProjectYield("demo", sessions, commits);
+    expect(yld.weekly.length).toBe(3);
+    const wk1 = yld.weekly.find((w) => w.weekStart === "2026-04-06");
+    expect(wk1?.commits).toBe(1);
+    expect(wk1?.costPerCommit).toBeCloseTo(2.0);
+    const wk3 = yld.weekly.find((w) => w.weekStart === "2026-04-20");
+    expect(wk3?.commits).toBe(0);
+    expect(wk3?.costPerCommit).toBeNull();
+    expect(yld.spendWithoutCommit).toHaveLength(1);
+    expect(yld.spendWithoutCommit[0]?.sessionId).toBe("s3");
+  });
+});
+
+describe("git/correlate — mondayOfWeekIso", () => {
+  it("snaps a Wednesday to the preceding Monday", () => {
+    expect(mondayOfWeekIso("2026-04-08T15:00:00Z")).toBe("2026-04-06");
+  });
+
+  it("returns the same Monday when the input is already Monday", () => {
+    expect(mondayOfWeekIso("2026-04-06T00:00:00Z")).toBe("2026-04-06");
+  });
+
+  it("snaps a Sunday back to the preceding Monday (ISO week)", () => {
+    expect(mondayOfWeekIso("2026-04-12T23:00:00Z")).toBe("2026-04-06");
+  });
+});

--- a/src/git/correlate.ts
+++ b/src/git/correlate.ts
@@ -1,0 +1,271 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { SessionSummary } from "../store/sqlite.js";
+
+export interface Commit {
+  hash: string;
+  authorDate: string; // ISO
+  authorName: string;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  subject: string;
+}
+
+export interface SessionYield {
+  sessionId: string;
+  costUsd: number;
+  commits: Commit[];
+  totalInsertions: number;
+  totalDeletions: number;
+  totalFilesChanged: number;
+  costPerCommit: number | null;
+  costPerLineChanged: number | null;
+}
+
+export interface ProjectYieldRow {
+  weekStart: string; // ISO Monday of the bucket
+  costUsd: number;
+  commits: number;
+  costPerCommit: number | null;
+}
+
+export interface ProjectYield {
+  project: string;
+  weekly: ProjectYieldRow[];
+  spendWithoutCommit: SessionYield[];
+}
+
+/** Window the session is allowed to claim commits in: [first_ts,
+ *  last_ts + COMMIT_GRACE_MS]. The grace period accommodates the
+ *  natural gap between the agent finishing edits and the human / agent
+ *  running `git commit`. */
+const COMMIT_GRACE_MS = 30 * 60 * 1000;
+
+/** Read-only — never invoke mutating git verbs. The worst this can do
+ *  is fail to start (no git on PATH) or time out. */
+const READ_ONLY_GIT_VERBS = new Set([
+  "log",
+  "rev-parse",
+  "worktree",
+  "config",
+  "branch",
+  "show",
+  "blame",
+  "diff",
+  "status",
+  "remote",
+]);
+
+function runGit(args: string[], opts: { cwd?: string; timeoutMs?: number } = {}): string {
+  const verb = args[0];
+  if (!verb || !READ_ONLY_GIT_VERBS.has(verb)) {
+    // Defensive — refuse to spawn git with a verb that could mutate
+    // state. This module is read-only by contract.
+    throw new Error(`git verb "${verb}" not in read-only allow-list`);
+  }
+  const result = spawnSync("git", args, {
+    cwd: opts.cwd,
+    encoding: "utf-8",
+    timeout: opts.timeoutMs ?? 10_000,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} exited ${result.status}: ${result.stderr.slice(0, 500)}`,
+    );
+  }
+  return result.stdout;
+}
+
+/** Discover the canonical git root for a `[name]` project tag.
+ *
+ *  Rule: walk one level under `workspaceRoot` looking for a directory
+ *  whose basename matches `projectName` and which contains a `.git`
+ *  entry (directory for a normal repo, file for a worktree). For
+ *  worktrees we resolve via `git rev-parse --git-common-dir` so two
+ *  paths sharing the same backing repo are treated as one project. */
+export function findProjectGitRoot(
+  workspaceRoot: string,
+  projectName: string,
+): string | null {
+  if (!existsSync(workspaceRoot)) return null;
+  let entries: string[];
+  try {
+    entries = readdirSync(workspaceRoot);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (entry !== projectName) continue;
+    const candidate = join(workspaceRoot, entry);
+    try {
+      const s = statSync(candidate);
+      if (!s.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const gitEntry = join(candidate, ".git");
+    if (!existsSync(gitEntry)) continue;
+    return resolve(candidate);
+  }
+  return null;
+}
+
+/** Get the canonical common-dir for a worktree so two checkouts of
+ *  the same repo aren't double-counted. Returns `null` for the input
+ *  path itself if `git rev-parse` fails. */
+export function gitCommonDir(repoPath: string): string | null {
+  try {
+    const out = runGit(["rev-parse", "--git-common-dir"], { cwd: repoPath });
+    const trimmed = out.trim();
+    if (!trimmed) return null;
+    // git rev-parse returns a relative path on some systems; normalize.
+    return resolve(repoPath, trimmed);
+  } catch {
+    return null;
+  }
+}
+
+/** List commits in `[since, until]` (both ISO). Returns oldest-first.
+ *  Skips merge commits (--no-merges) so the cost-per-commit metric
+ *  isn't diluted by routine integration commits. */
+export function listCommits(
+  repoPath: string,
+  opts: { since?: string; until?: string } = {},
+): Commit[] {
+  const args = ["log", "--no-merges", "--reverse"];
+  if (opts.since) args.push(`--since=${opts.since}`);
+  if (opts.until) args.push(`--until=${opts.until}`);
+  // Format: STX prefix on every commit header so the parser can split
+  // records cleanly even though --numstat injects extra lines between
+  // commits. Field separator is unit-separator (\x1f) — robust against
+  // tabs and newlines in subjects.
+  args.push("--pretty=format:%x02%H%x1f%aI%x1f%an%x1f%s", "--numstat");
+  let out: string;
+  try {
+    out = runGit(args, { cwd: repoPath });
+  } catch {
+    return [];
+  }
+  const records = out.split("\x02").map((r) => r.trim()).filter(Boolean);
+  const commits: Commit[] = [];
+  for (const rec of records) {
+    const headerEnd = rec.indexOf("\n");
+    const header = headerEnd === -1 ? rec : rec.slice(0, headerEnd);
+    const numstat = headerEnd === -1 ? "" : rec.slice(headerEnd + 1);
+    const [hash, authorDate, authorName, subject] = header.split("\x1f");
+    if (!hash || !authorDate) continue;
+    let insertions = 0;
+    let deletions = 0;
+    let files = 0;
+    for (const line of numstat.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const parts = trimmed.split(/\s+/);
+      const ins = parts[0] === "-" ? 0 : Number(parts[0] ?? "0");
+      const del = parts[1] === "-" ? 0 : Number(parts[1] ?? "0");
+      if (Number.isFinite(ins)) insertions += ins;
+      if (Number.isFinite(del)) deletions += del;
+      files += 1;
+    }
+    commits.push({
+      hash,
+      authorDate,
+      authorName: authorName ?? "",
+      filesChanged: files,
+      insertions,
+      deletions,
+      subject: subject ?? "",
+    });
+  }
+  return commits;
+}
+
+/** Pair a session with the commits whose author_date sits inside the
+ *  session window (first_ts → last_ts + 30min grace). Yields the
+ *  cost-per-commit and cost-per-line metrics for the UI. */
+export function correlateSessionYield(
+  session: SessionSummary,
+  commits: Commit[],
+): SessionYield {
+  const firstMs = Date.parse(session.firstTs);
+  const lastMs = Date.parse(session.lastTs);
+  const upper = Number.isFinite(lastMs) ? lastMs + COMMIT_GRACE_MS : Infinity;
+  const lower = Number.isFinite(firstMs) ? firstMs : -Infinity;
+
+  const matched = commits.filter((c) => {
+    const t = Date.parse(c.authorDate);
+    if (!Number.isFinite(t)) return false;
+    return t >= lower && t <= upper;
+  });
+
+  let totalInsertions = 0;
+  let totalDeletions = 0;
+  let totalFiles = 0;
+  for (const c of matched) {
+    totalInsertions += c.insertions;
+    totalDeletions += c.deletions;
+    totalFiles += c.filesChanged;
+  }
+  const totalLines = totalInsertions + totalDeletions;
+  return {
+    sessionId: session.sessionId,
+    costUsd: session.costUsd,
+    commits: matched,
+    totalInsertions,
+    totalDeletions,
+    totalFilesChanged: totalFiles,
+    costPerCommit: matched.length > 0 ? session.costUsd / matched.length : null,
+    costPerLineChanged: totalLines > 0 ? session.costUsd / totalLines : null,
+  };
+}
+
+/** Aggregate yields across every session in a project — weekly cost-
+ *  per-commit + a list of "spend without commit" sessions where the
+ *  agent burned dollars but produced no commits. */
+export function aggregateProjectYield(
+  project: string,
+  sessions: SessionSummary[],
+  commits: Commit[],
+): ProjectYield {
+  const yields = sessions.map((s) => correlateSessionYield(s, commits));
+  const weekly = new Map<string, { cost: number; commits: Set<string> }>();
+  for (const y of yields) {
+    const session = sessions.find((s) => s.sessionId === y.sessionId);
+    if (!session) continue;
+    const week = mondayOfWeekIso(session.firstTs);
+    let bucket = weekly.get(week);
+    if (!bucket) {
+      bucket = { cost: 0, commits: new Set() };
+      weekly.set(week, bucket);
+    }
+    bucket.cost += session.costUsd;
+    for (const c of y.commits) bucket.commits.add(c.hash);
+  }
+  const weeklyRows: ProjectYieldRow[] = Array.from(weekly.entries())
+    .map(([weekStart, b]) => ({
+      weekStart,
+      costUsd: b.cost,
+      commits: b.commits.size,
+      costPerCommit: b.commits.size > 0 ? b.cost / b.commits.size : null,
+    }))
+    .sort((a, b) => (a.weekStart < b.weekStart ? -1 : 1));
+  const spendWithoutCommit = yields
+    .filter((y) => y.commits.length === 0 && y.costUsd > 0)
+    .sort((a, b) => b.costUsd - a.costUsd);
+  return { project, weekly: weeklyRows, spendWithoutCommit };
+}
+
+export function mondayOfWeekIso(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const day = d.getUTCDay(); // 0..6 (Sun..Sat)
+  const offsetToMonday = day === 0 ? -6 : 1 - day;
+  const monday = new Date(d);
+  monday.setUTCDate(d.getUTCDate() + offsetToMonday);
+  monday.setUTCHours(0, 0, 0, 0);
+  return monday.toISOString().slice(0, 10);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { registerAgentRoutes } from "./routes/agents.js";
 import { registerPermissionRoutes } from "./routes/permissions.js";
 import { registerCronRoutes } from "./routes/cron.js";
 import { registerSearchRoutes } from "./routes/search.js";
+import { registerYieldRoutes } from "./routes/yield.js";
 import type { EventStore } from "../store/sqlite.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerTrendsRoutes } from "./routes/trends.js";
@@ -154,6 +155,7 @@ export async function startServer(opts: StartServerOptions): Promise<ServerHandl
   registerPermissionRoutes(app);
   registerCronRoutes(app, events);
   registerSearchRoutes(app, events, opts.store);
+  registerYieldRoutes(app, opts.store);
   registerConfigRoutes(app);
   registerTrendsRoutes(app, events);
   registerDiffRoutes(app, events);

--- a/src/server/routes/yield.ts
+++ b/src/server/routes/yield.ts
@@ -1,0 +1,105 @@
+import type { FastifyInstance } from "fastify";
+import {
+  aggregateProjectYield,
+  correlateSessionYield,
+  findProjectGitRoot,
+  listCommits,
+} from "../../git/correlate.js";
+import type { EventStore } from "../../store/sqlite.js";
+import { detectWorkspaceRoot } from "../../util/workspace.js";
+
+/** `$/commit` and `$/line` views — pairs sessions and projects with the
+ *  commits that landed during their time window. Returns empty payloads
+ *  when no store is attached or the project isn't a git repo under
+ *  WORKSPACE_ROOT. Read-only. */
+export function registerYieldRoutes(
+  app: FastifyInstance,
+  store?: EventStore,
+): void {
+  app.get<{ Params: { id: string } }>(
+    "/api/sessions/:id/yield",
+    async (req, reply) => {
+      const id = decodeURIComponent(req.params.id);
+      if (!store) return { sessionId: id, ok: false, reason: "no store" };
+      const sessions = store.listSessions({ limit: 1, since: undefined });
+      const session = store.listSessions({ limit: 5000 }).find(
+        (s) => s.sessionId === id,
+      );
+      if (!session) {
+        reply.code(404);
+        return { sessionId: id, ok: false, reason: "session not found" };
+      }
+      void sessions;
+      if (!session.project) {
+        return {
+          sessionId: id,
+          ok: false,
+          reason: "session has no project tag",
+        };
+      }
+      const repo = findProjectGitRoot(detectWorkspaceRoot(), session.project);
+      if (!repo) {
+        return {
+          sessionId: id,
+          ok: false,
+          reason: "project is not a git repo under WORKSPACE_ROOT",
+        };
+      }
+      const commits = listCommits(repo, {
+        since: session.firstTs,
+        until: new Date(
+          Date.parse(session.lastTs) + 60 * 60 * 1000,
+        ).toISOString(),
+      });
+      return {
+        sessionId: id,
+        ok: true,
+        project: session.project,
+        repoPath: repo,
+        yield: correlateSessionYield(session, commits),
+      };
+    },
+  );
+
+  app.get<{ Params: { name: string } }>(
+    "/api/projects/:name/yield",
+    async (req) => {
+      const name = decodeURIComponent(req.params.name);
+      if (!store) return { project: name, ok: false, reason: "no store" };
+      const repo = findProjectGitRoot(detectWorkspaceRoot(), name);
+      if (!repo) {
+        return {
+          project: name,
+          ok: false,
+          reason: "project is not a git repo under WORKSPACE_ROOT",
+        };
+      }
+      const sessions = store.listSessions({ project: name, limit: 5000 });
+      if (sessions.length === 0) {
+        return { project: name, ok: true, repoPath: repo, yield: emptyYield(name) };
+      }
+      const earliest = sessions
+        .map((s) => s.firstTs)
+        .sort()[0] ?? new Date().toISOString();
+      const latest = sessions.map((s) => s.lastTs).sort().pop() ?? new Date().toISOString();
+      const commits = listCommits(repo, {
+        since: earliest,
+        until: new Date(Date.parse(latest) + 60 * 60 * 1000).toISOString(),
+      });
+      return {
+        project: name,
+        ok: true,
+        repoPath: repo,
+        yield: aggregateProjectYield(name, sessions, commits),
+      };
+    },
+  );
+}
+
+function emptyYield(project: string): {
+  project: string;
+  weekly: never[];
+  spendWithoutCommit: never[];
+} {
+  return { project, weekly: [], spendWithoutCommit: [] };
+}


### PR DESCRIPTION
## Summary

Answers the question every developer asks: *"is this AI spend producing code, or am I just chatting?"* — by pairing sessions with the git commits that landed during their time window.

**`src/git/correlate.ts`** — the entire git interaction is read-only. The `runGit` helper allow-lists nine read-only verbs (`log`, `rev-parse`, `worktree`, `show`, `diff`, `blame`, `status`, `config`, `branch`, `remote`); any other verb throws before spawning. Functions:

- `findProjectGitRoot(workspaceRoot, projectName)` — walks one level under `WORKSPACE_ROOT` looking for a basename match with a `.git` entry. Returns absolute path or `null`.
- `gitCommonDir(repoPath)` — for worktree de-dup; two checkouts that share a backing repo share commits, so we use the canonical common-dir.
- `listCommits(repoPath, { since, until })` — `--no-merges`, `--numstat`, `--pretty=format:%x02%H%x1f%aI%x1f%an%x1f%s` so the parser can split on STX-prefixed records and unit-separator fields without tripping on subjects with newlines or tabs.
- `correlateSessionYield(session, commits)` — matches commits whose author date is in `[first_ts, last_ts + 30min]`. Returns `costPerCommit`, `costPerLineChanged`, totals.
- `aggregateProjectYield(project, sessions, commits)` — buckets cost + commits per ISO week (Monday-anchored) and surfaces a sorted "spend without commit" list.

**New routes:** `GET /api/sessions/:id/yield`, `GET /api/projects/:name/yield`. Both return `ok: false` with a reason when there's no store, no project tag on the session, or no git repo at the resolved path under `WORKSPACE_ROOT`.

## Out of scope (filed as follow-up)

- **React `/sessions/:id/yield` and `/projects/:name/yield` views** in the web UI. The API ships now — the visualization is its own UI ticket.
- **Cross-author attribution.** Per the ticket, v0.1 attributes all in-window commits to whichever agent was active. Multi-human + agent attribution is a v0.2 concern.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **293/293** pass (14 new tests use real git repos via `execSync`)
  - findProjectGitRoot positive + negative cases
  - listCommits returns ISO author dates / insertions / deletions
  - --since / --until window filtering
  - correlateSessionYield matches in-window, drops out-of-window
  - cost-per-commit and cost-per-line math
  - null on empty match
  - aggregateProjectYield buckets per ISO week + spend-without-commit list
  - mondayOfWeekIso edge cases (Monday, Wednesday, Sunday)
- [x] `npm run build` succeeds

## Stacking

Base = PR #16. Stack: PR #15 → PR #16 → PR #17 (daemon) → PR #18 (classifier) → this. CHANGELOG entry deferred to release-cut.

Closes [AUR-265](https://linear.app/auraqu/issue/AUR-265/v01-git-correlation-yield-view-sessions-commits-commit).