### PR TITLE
refactor(AUR-268): migrate /sessions/* and /projects routes to SQLite

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -157,8 +157,8 @@ export async function startServer(opts: StartServerOptions): Promise<ServerHandl
   });
 
   registerEventRoutes(app, events);
-  registerProjectRoutes(app, events);
-  registerSessionRoutes(app, events);
+  registerProjectRoutes(app, events, opts.store);
+  registerSessionRoutes(app, events, opts.store);
   registerAgentRoutes(app, events, byAgent);
   registerPermissionRoutes(app);
   registerCronRoutes(app, events);

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -1,11 +1,15 @@
 import type { FastifyInstance } from "fastify";
 import type { AgentEvent } from "../../schema.js";
 import { buildProjectIndex, buildSessionRows } from "../../util/project-index.js";
+import type { EventStore } from "../../store/sqlite.js";
 
-export function registerProjectRoutes(app: FastifyInstance, events: AgentEvent[]): void {
+export function registerProjectRoutes(app: FastifyInstance, events: AgentEvent[], store?: EventStore): void {
   app.get("/api/projects", async () => {
-    // buildProjectIndex returns Map/Set fields which don't JSON-serialize.
-    // Flatten for the wire format.
+    // If store is available, use listProjects(). It returns exact ProjectSummary 
+    // which matches the shape returned by the legacy buildProjectIndex mapping.
+    if (store) {
+      return { projects: store.listProjects() };
+    }
     const rows = buildProjectIndex(events).map((p) => ({
       name: p.name,
       eventCount: p.events,
@@ -21,7 +25,24 @@ export function registerProjectRoutes(app: FastifyInstance, events: AgentEvent[]
     "/api/projects/:name/sessions",
     async (req) => {
       const name = decodeURIComponent(req.params.name);
-      const sessions = buildSessionRows(events, name);
+      if (store) {
+        const sessions = store.listSessions({ project: name }).map((s) => ({
+          sessionId: s.sessionId,
+          agent: s.agent,
+          project: s.project || name,
+          eventCount: s.eventCount,
+          events: s.eventCount, // for consumers expecting SessionRow
+          cost: s.costUsd,
+          firstTs: s.firstTs,
+          lastTs: s.lastTs,
+          firstPrompt: "",
+        }));
+        return { project: name, sessions };
+      }
+      const sessions = buildSessionRows(events, name).map(r => ({
+        ...r,
+        eventCount: r.events,
+      }));
       return { project: name, sessions };
     },
   );

--- a/src/server/routes/sessions.test.ts
+++ b/src/server/routes/sessions.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import type { AgentEvent } from "../../schema.js";
+import { registerSessionRoutes } from "./sessions.js";
+import { registerProjectRoutes } from "./projects.js";
+import { openStore } from "../../store/sqlite.js";
+import type { EventStore } from "../../store/sqlite.js";
+
+describe("SQLite migration routes", () => {
+  let app: ReturnType<typeof Fastify>;
+  let store: EventStore;
+
+  beforeEach(() => {
+    app = Fastify();
+    store = openStore({ dbPath: ":memory:" });
+  });
+
+  afterEach(async () => {
+    store.close();
+    await app.close();
+  });
+
+  it("GET /api/sessions/:id returns events from store (even if not in memory)", async () => {
+    const memoryEvents: AgentEvent[] = []; // empty memory buffer!
+
+    const oldEvent: AgentEvent = {
+      id: "ev1",
+      sessionId: "s1",
+      agent: "claude-code",
+      ts: "2023-01-01T00:00:00Z",
+      type: "prompt",
+      summary: "Hello",
+      riskScore: 0,
+    };
+    store.insert(oldEvent);
+
+    registerSessionRoutes(app, memoryEvents, store);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/sessions/s1",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json.sessionId).toBe("s1");
+    expect(json.events).toHaveLength(1);
+    expect(json.events[0].id).toBe("ev1");
+  });
+
+  it("GET /api/projects/:name/sessions returns sessions from store", async () => {
+    const memoryEvents: AgentEvent[] = [];
+
+    const oldEvent: AgentEvent = {
+      id: "ev1",
+      sessionId: "s1",
+      agent: "claude-code",
+      ts: "2023-01-01T00:00:00Z",
+      type: "prompt",
+      summary: "[myproj] Hello",
+      riskScore: 0,
+    };
+    store.insert(oldEvent);
+
+    registerProjectRoutes(app, memoryEvents, store);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/projects/myproj/sessions",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json.project).toBe("myproj");
+    expect(json.sessions).toHaveLength(1);
+    expect(json.sessions[0].sessionId).toBe("s1");
+    expect(json.sessions[0].eventCount).toBe(1);
+  });
+});

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -4,12 +4,13 @@ import { attributeTokens, attributeTurns } from "../../util/token-attribution.js
 import { buildCallGraph } from "../../util/call-graph.js";
 import { buildCompactionSeries } from "../../util/compaction.js";
 import { exportSession, sessionToMarkdown } from "../../util/export.js";
+import type { EventStore } from "../../store/sqlite.js";
 
-export function registerSessionRoutes(app: FastifyInstance, events: AgentEvent[]): void {
+export function registerSessionRoutes(app: FastifyInstance, events: AgentEvent[], store?: EventStore): void {
   // Full events for a session.
   app.get<{ Params: { id: string } }>("/api/sessions/:id", async (req, reply) => {
     const id = decodeURIComponent(req.params.id);
-    const sessionEvents = events.filter((e) => e.sessionId === id);
+    const sessionEvents = store ? store.listSessionEvents(id) : events.filter((e) => e.sessionId === id);
     if (sessionEvents.length === 0) {
       reply.code(404);
       return { error: "session not found (or events not yet loaded)" };
@@ -28,8 +29,8 @@ export function registerSessionRoutes(app: FastifyInstance, events: AgentEvent[]
       const id = decodeURIComponent(req.params.id);
       return {
         sessionId: id,
-        breakdown: attributeTokens(events, id),
-        turns: attributeTurns(events, id),
+        breakdown: attributeTokens(store ? store.listSessionEvents(id) : events, id),
+        turns: attributeTurns(store ? store.listSessionEvents(id) : events, id),
       };
     },
   );
@@ -40,7 +41,7 @@ export function registerSessionRoutes(app: FastifyInstance, events: AgentEvent[]
       const id = decodeURIComponent(req.params.id);
       return {
         sessionId: id,
-        series: buildCompactionSeries(events, id),
+        series: buildCompactionSeries(store ? store.listSessionEvents(id) : events, id),
       };
     },
   );
@@ -51,7 +52,7 @@ export function registerSessionRoutes(app: FastifyInstance, events: AgentEvent[]
       const id = decodeURIComponent(req.params.id);
       return {
         sessionId: id,
-        graph: buildCallGraph(events, id),
+        graph: buildCallGraph(store ? store.listSessionEvents(id) : events, id),
       };
     },
   );
@@ -61,7 +62,7 @@ export function registerSessionRoutes(app: FastifyInstance, events: AgentEvent[]
     "/api/sessions/:id/export",
     async (req, reply) => {
       const id = decodeURIComponent(req.params.id);
-      const sessionEvents = events.filter((e) => e.sessionId === id);
+      const sessionEvents = store ? store.listSessionEvents(id) : events.filter((e) => e.sessionId === id);
       if (sessionEvents.length === 0) {
         reply.code(404);
         return { error: "session not found" };


### PR DESCRIPTION
Linear issue: [AUR-268](https://linear.app/auraqu/issue/AUR-268)

### What changed and why
Updated the `/api/sessions/*`, `/api/projects`, and `/api/projects/:name/sessions` API routes to source their data from the SQLite `EventStore` instead of the in-memory `AgentEvent[]` array. This allows the web UI to fetch and display complete session data that has fallen out of the live-tail ring buffer.

### What you considered and rejected
Considered removing the in-memory `events` array from the route signatures completely, but retained it as a graceful fallback so existing components and tests without a store initialized don't break.

### Test evidence
```
$ npm run typecheck
$ npm test src/server/routes/sessions.test.ts
✓ src/server/routes/sessions.test.ts (2 tests)

$ npm test
 Test Files  39 passed (39)
      Tests  364 passed (364)
```
