### PR TITLE
chore: glama.json + Glama badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ semantic conventions. All local. No cloud. No telemetry. No sign-in.
 [![CI](https://github.com/mishanefedov/agentwatch/actions/workflows/ci.yml/badge.svg)](https://github.com/mishanefedov/agentwatch/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Node >=20](https://img.shields.io/badge/node-%E2%89%A520-brightgreen.svg)](./package.json)
+[![MCP server](https://glama.ai/mcp/servers/mishanefedov/agentwatch/badges/score.svg)](https://glama.ai/mcp/servers/mishanefedov/agentwatch)
+
+</div>
+
+<div align="center">
+
+[![agentwatch on Glama](https://glama.ai/mcp/servers/mishanefedov/agentwatch/badges/card.svg)](https://glama.ai/mcp/servers/mishanefedov/agentwatch)
 
 </div>
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["mishanefedov"]
+}


### PR DESCRIPTION
## Summary

Adds the minimal `glama.json` ($schema + maintainers: [mishanefedov]) and the Glama score + card badges to the README. Required to unblock the awesome-mcp-servers PR (https://github.com/punkpeye/awesome-mcp-servers#5665) — Glama needs to find a parseable glama.json and at least one tagged release before it computes a quality score.

## Test plan

- [x] glama.json validates against https://glama.ai/mcp/schemas/server.json
- [x] README badges resolve to live images
- [x] No code changes — pure metadata + docs

After merge:
- Glama's next scan should populate Server Coherence + Tool Definition Quality + flip 'No Glama release' (already addressed via the v0.0.5 release tag I cut today) → quality score appears → awesome-mcp-servers PR unblocked.