### PR TITLE
feat(web): React activity views — sessions + projects (AUR-269)

### DIFF
--- a/src/store/sqlite.test.ts
+++ b/src/store/sqlite.test.ts
@@ -371,6 +371,21 @@ describe("sqlite store — activity rollups (v2)", () => {
     expect(buckets[0]?.category).toBe("coding");
     expect(buckets[0]?.eventCount).toBe(2);
     expect(buckets[0]?.costUsd).toBeCloseTo(0.30);
+    expect(buckets[0]?.sessionsTouched).toBe(2);
+  });
+
+  it("activityByProject sessionsTouched counts distinct sessions per category", () => {
+    store.insertMany([
+      makeEvent({ id: "x1", sessionId: "s1", summary: "[acme] a", details: { category: "coding" } }),
+      makeEvent({ id: "x2", sessionId: "s1", summary: "[acme] b", details: { category: "coding" } }),
+      makeEvent({ id: "x3", sessionId: "s2", summary: "[acme] c", details: { category: "coding" } }),
+      makeEvent({ id: "x4", sessionId: "s3", summary: "[acme] d", details: { category: "testing" } }),
+    ]);
+    const buckets = store.activityByProject("acme");
+    const coding = buckets.find((b) => b.category === "coding");
+    const testing = buckets.find((b) => b.category === "testing");
+    expect(coding?.sessionsTouched).toBe(2);
+    expect(testing?.sessionsTouched).toBe(1);
   });
 
   it("uses 'chat' as the bucket label for events without a category", () => {

--- a/src/store/sqlite.ts
+++ b/src/store/sqlite.ts
@@ -65,6 +65,9 @@ export interface ActivityBucket {
   category: string;
   eventCount: number;
   costUsd: number;
+  /** Distinct sessions in this category. Only populated by activityByProject;
+   *  always 0 (or absent) for activityBySession. */
+  sessionsTouched?: number;
 }
 
 export interface EventStore {
@@ -556,7 +559,8 @@ function buildStore(db: Database.Database): EventStore {
         .prepare(
           `SELECT COALESCE(category, 'chat') AS category,
                   COUNT(*) AS event_count,
-                  COALESCE(SUM(cost_usd), 0) AS cost_total
+                  COALESCE(SUM(cost_usd), 0) AS cost_total,
+                  COUNT(DISTINCT session_id) AS sessions_touched
            FROM events
            WHERE project = ?
            GROUP BY COALESCE(category, 'chat')`,
@@ -565,12 +569,14 @@ function buildStore(db: Database.Database): EventStore {
         category: string;
         event_count: number;
         cost_total: number;
+        sessions_touched: number;
       }>;
       return rows
         .map((r) => ({
           category: r.category,
           eventCount: r.event_count,
           costUsd: r.cost_total,
+          sessionsTouched: r.sessions_touched,
         }))
         .sort((a, b) => b.eventCount - a.eventCount);
     },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,23 @@ export const api = {
       `/api/sessions/${encodeURIComponent(id)}/graph`,
     ),
 
+  sessionActivity: (id: string) =>
+    getJson<{
+      sessionId: string;
+      buckets: Array<{ category: string; eventCount: number; costUsd: number }>;
+    }>(`/api/sessions/${encodeURIComponent(id)}/activity`),
+
+  projectActivity: (name: string) =>
+    getJson<{
+      project: string;
+      buckets: Array<{
+        category: string;
+        eventCount: number;
+        costUsd: number;
+        sessionsTouched?: number;
+      }>;
+    }>(`/api/projects/${encodeURIComponent(name)}/activity`),
+
   search: (
     query: string,
     mode: "live" | "cross" | "semantic" = "live",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -51,6 +51,7 @@ export interface AgentEvent {
     durationMs?: number;
     toolError?: boolean;
     subAgentId?: string;
+    category?: string;
   };
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -23,6 +23,8 @@ const SessionCompactionPage = lazy(() => import("./routes/SessionCompaction").th
 const SessionGraphPage = lazy(() => import("./routes/SessionGraph").then((m) => ({ default: m.SessionGraphPage })));
 const SessionDiffsPage = lazy(() => import("./routes/SessionDiffs").then((m) => ({ default: m.SessionDiffsPage })));
 const SessionReplayPage = lazy(() => import("./routes/SessionReplay").then((m) => ({ default: m.SessionReplayPage })));
+const SessionActivityPage = lazy(() => import("./routes/SessionActivity").then((m) => ({ default: m.SessionActivityPage })));
+const ProjectActivityPage = lazy(() => import("./routes/ProjectActivity").then((m) => ({ default: m.ProjectActivityPage })));
 const TrendsPage = lazy(() => import("./routes/Trends").then((m) => ({ default: m.TrendsPage })));
 const SettingsShell = lazy(() => import("./routes/Settings").then((m) => ({ default: m.SettingsShell })));
 const BudgetsSettings = lazy(() => import("./routes/Settings").then((m) => ({ default: m.BudgetsSettings })));
@@ -54,6 +56,8 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             <Route path="sessions/:id/graph" element={L(<SessionGraphPage />)} />
             <Route path="sessions/:id/diffs" element={L(<SessionDiffsPage />)} />
             <Route path="sessions/:id/replay" element={L(<SessionReplayPage />)} />
+            <Route path="sessions/:id/activity" element={L(<SessionActivityPage />)} />
+            <Route path="projects/:name/activity" element={L(<ProjectActivityPage />)} />
             <Route path="events/:id" element={<EventDetailPage />} />
             <Route path="search" element={<SearchPage />} />
             <Route path="logs" element={<LogsPage />} />

--- a/web/src/routes/ProjectActivity.tsx
+++ b/web/src/routes/ProjectActivity.tsx
@@ -1,0 +1,217 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+import { api } from "../lib/api";
+import { formatUSD } from "../lib/format";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { ArrowLeft } from "lucide-react";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  coding: "#3fb950",
+  debugging: "#f85149",
+  exploration: "#58a6ff",
+  planning: "#bc8cff",
+  refactor: "#d29922",
+  testing: "#39d353",
+  docs: "#8b949e",
+  chat: "#7d8590",
+  config: "#e3b341",
+  review: "#a371f7",
+  devops: "#ff7b72",
+  research: "#79c0ff",
+};
+
+function colorFor(category: string): string {
+  return CATEGORY_COLORS[category] ?? "#7d8590";
+}
+
+export function ProjectActivityPage() {
+  const { name = "" } = useParams();
+  const decoded = decodeURIComponent(name);
+
+  const q = useQuery({
+    queryKey: ["project-activity", name],
+    queryFn: () => api.projectActivity(name),
+    refetchInterval: 5_000,
+  });
+
+  const buckets = q.data?.buckets ?? [];
+  const totalEvents = buckets.reduce((s, b) => s + b.eventCount, 0);
+  const totalCost = buckets.reduce((s, b) => s + b.costUsd, 0);
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="px-5 py-4 border-b border-bg-border flex items-baseline gap-3">
+        <Link to={`/projects/${encodeURIComponent(decoded)}`} className="text-fg-dim hover:text-accent">
+          <ArrowLeft className="w-4 h-4 inline" />
+        </Link>
+        <h1 className="text-lg font-bold">activity</h1>
+        <span className="text-sm text-fg-dim mono">{decoded}</span>
+      </div>
+
+      {q.isLoading && <div className="p-6 text-fg-dim">loading…</div>}
+
+      {!q.isLoading && totalEvents === 0 && (
+        <div className="p-6 text-fg-dim">
+          no classified events yet for this project.
+        </div>
+      )}
+
+      {!q.isLoading && totalEvents > 0 && (
+        <>
+          <div className="px-5 py-4 grid grid-cols-2 md:grid-cols-4 gap-3 border-b border-bg-border">
+            <Stat label="categories" value={String(buckets.length)} />
+            <Stat label="events" value={String(totalEvents)} />
+            <Stat label="total cost" value={formatUSD(totalCost)} />
+            <Stat
+              label="sessions"
+              value={String(
+                buckets.reduce(
+                  (s, b) => s + (b.sessionsTouched ?? 0),
+                  0,
+                ),
+              )}
+            />
+          </div>
+
+          <div className="p-5 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <div className="text-xs uppercase text-fg-muted mb-2">
+                events by category
+              </div>
+              <div
+                className="bg-bg-surface border border-bg-border rounded-lg p-3"
+                style={{ height: 300 }}
+              >
+                <ResponsiveContainer>
+                  <PieChart>
+                    <Pie
+                      data={buckets}
+                      dataKey="eventCount"
+                      nameKey="category"
+                      cx="50%"
+                      cy="50%"
+                      outerRadius={90}
+                      label={(p: { name?: string; percent?: number }) =>
+                        `${p.name ?? ""} ${p.percent != null ? `${(p.percent * 100).toFixed(0)}%` : ""}`
+                      }
+                    >
+                      {buckets.map((b) => (
+                        <Cell key={b.category} fill={colorFor(b.category)} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      contentStyle={{
+                        background: "#0b0d10",
+                        border: "1px solid #2b3139",
+                        fontSize: 11,
+                      }}
+                    />
+                    <Legend wrapperStyle={{ fontSize: 11 }} />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+
+            <div>
+              <div className="text-xs uppercase text-fg-muted mb-2">
+                cost by category
+              </div>
+              <div
+                className="bg-bg-surface border border-bg-border rounded-lg p-3"
+                style={{ height: 300 }}
+              >
+                <ResponsiveContainer>
+                  <PieChart>
+                    <Pie
+                      data={buckets.filter((b) => b.costUsd > 0)}
+                      dataKey="costUsd"
+                      nameKey="category"
+                      cx="50%"
+                      cy="50%"
+                      outerRadius={90}
+                      label={(p: { name?: string; percent?: number }) =>
+                        `${p.name ?? ""} ${p.percent != null ? `${(p.percent * 100).toFixed(0)}%` : ""}`
+                      }
+                    >
+                      {buckets
+                        .filter((b) => b.costUsd > 0)
+                        .map((b) => (
+                          <Cell key={b.category} fill={colorFor(b.category)} />
+                        ))}
+                    </Pie>
+                    <Tooltip
+                      contentStyle={{
+                        background: "#0b0d10",
+                        border: "1px solid #2b3139",
+                        fontSize: 11,
+                      }}
+                    />
+                    <Legend wrapperStyle={{ fontSize: 11 }} />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </div>
+
+          <div className="px-5 pb-6">
+            <div className="text-xs uppercase text-fg-muted mb-2">
+              per-category breakdown
+            </div>
+            <table className="w-full text-sm">
+              <thead className="text-left text-xs uppercase text-fg-muted">
+                <tr>
+                  <th className="py-1">category</th>
+                  <th className="py-1">events</th>
+                  <th className="py-1">cost</th>
+                  <th className="py-1">sessions touched</th>
+                  <th className="py-1">% events</th>
+                  <th className="py-1">% cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {buckets.map((b) => (
+                  <tr key={b.category} className="mono text-xs border-b border-bg-border/30">
+                    <td className="py-1.5 flex items-center gap-2">
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-sm"
+                        style={{ background: colorFor(b.category) }}
+                      />
+                      {b.category}
+                    </td>
+                    <td className="py-1.5">{b.eventCount}</td>
+                    <td className="py-1.5">{formatUSD(b.costUsd)}</td>
+                    <td className="py-1.5">{b.sessionsTouched ?? "—"}</td>
+                    <td className="py-1.5 text-fg-dim">
+                      {`${((b.eventCount / totalEvents) * 100).toFixed(1)}%`}
+                    </td>
+                    <td className="py-1.5 text-fg-dim">
+                      {totalCost > 0
+                        ? `${((b.costUsd / totalCost) * 100).toFixed(1)}%`
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-bg-surface border border-bg-border rounded-md px-3 py-2">
+      <div className="text-[10px] uppercase text-fg-muted">{label}</div>
+      <div className="mono">{value}</div>
+    </div>
+  );
+}

--- a/web/src/routes/ProjectDetail.tsx
+++ b/web/src/routes/ProjectDetail.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../lib/api";
 import { agentColor, formatDateTime, formatUSD } from "../lib/format";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, PieChart } from "lucide-react";
 import clsx from "clsx";
 
 export function ProjectDetailPage() {
@@ -23,6 +23,12 @@ export function ProjectDetailPage() {
         </Link>
         <h1 className="text-lg font-bold">{decodeURIComponent(name)}</h1>
         <span className="text-sm text-fg-dim">{sessions.length} sessions</span>
+        <Link
+          to={`/projects/${encodeURIComponent(name)}/activity`}
+          className="ml-auto text-xs text-fg-dim hover:text-accent flex items-center gap-1"
+        >
+          <PieChart className="w-3.5 h-3.5" /> activity
+        </Link>
       </div>
       <table className="w-full text-sm">
         <thead className="sticky top-0 bg-bg-surface border-b border-bg-border">

--- a/web/src/routes/Session.tsx
+++ b/web/src/routes/Session.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../lib/api";
 import { agentColor, formatTime, riskClass, typeIcon } from "../lib/format";
-import { ArrowLeft, Download, BarChart3, Activity, GitBranch, FileEdit, Play } from "lucide-react";
+import { ArrowLeft, Download, BarChart3, Activity, GitBranch, FileEdit, Play, PieChart } from "lucide-react";
 import clsx from "clsx";
 import type { AgentEvent } from "../lib/types";
 
@@ -46,6 +46,9 @@ export function SessionPage() {
           </Link>
           <Link to={`/sessions/${encodeURIComponent(id)}/replay`} className="text-xs text-fg-dim hover:text-accent flex items-center gap-1">
             <Play className="w-3.5 h-3.5" /> replay
+          </Link>
+          <Link to={`/sessions/${encodeURIComponent(id)}/activity`} className="text-xs text-fg-dim hover:text-accent flex items-center gap-1">
+            <PieChart className="w-3.5 h-3.5" /> activity
           </Link>
           <a
             href={`/api/sessions/${encodeURIComponent(id)}/export?format=md&inline=1`}

--- a/web/src/routes/SessionActivity.tsx
+++ b/web/src/routes/SessionActivity.tsx
@@ -1,0 +1,201 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+import { api } from "../lib/api";
+import { formatUSD } from "../lib/format";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { ArrowLeft } from "lucide-react";
+import type { AgentEvent } from "../lib/types";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  coding: "#3fb950",
+  debugging: "#f85149",
+  exploration: "#58a6ff",
+  planning: "#bc8cff",
+  refactor: "#d29922",
+  testing: "#39d353",
+  docs: "#8b949e",
+  chat: "#7d8590",
+  config: "#e3b341",
+  review: "#a371f7",
+  devops: "#ff7b72",
+  research: "#79c0ff",
+};
+
+function colorFor(category: string): string {
+  return CATEGORY_COLORS[category] ?? "#7d8590";
+}
+
+/** Turn an ISO timestamp into a UTC minute-bucket key (YYYY-MM-DD HH:MM). */
+function bucketKey(ts: string): string {
+  return ts.slice(0, 16).replace("T", " ");
+}
+
+export function SessionActivityPage() {
+  const { id = "" } = useParams();
+
+  const sessionQ = useQuery({
+    queryKey: ["session", id],
+    queryFn: () => api.session(id),
+    refetchInterval: 5_000,
+  });
+  const activityQ = useQuery({
+    queryKey: ["session-activity", id],
+    queryFn: () => api.sessionActivity(id),
+    refetchInterval: 5_000,
+  });
+
+  const { chartData, categories } = useMemo(() => {
+    const events: AgentEvent[] = sessionQ.data?.events ?? [];
+    if (events.length === 0) return { chartData: [], categories: [] as string[] };
+    const cats = new Set<string>();
+    const byBucket = new Map<string, Record<string, number>>();
+    for (const e of events) {
+      const cat = (e.details?.category as string | undefined) ?? "chat";
+      cats.add(cat);
+      const k = bucketKey(e.ts);
+      let row = byBucket.get(k);
+      if (!row) {
+        row = { _bucket: 0 } as unknown as Record<string, number>;
+        byBucket.set(k, row);
+      }
+      row[cat] = (row[cat] ?? 0) + 1;
+    }
+    const ordered = Array.from(byBucket.entries())
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([k, v]) => ({ bucket: k, ...v }));
+    return { chartData: ordered, categories: Array.from(cats).sort() };
+  }, [sessionQ.data]);
+
+  const buckets = activityQ.data?.buckets ?? [];
+  const totalCost = buckets.reduce((s, b) => s + b.costUsd, 0);
+  const totalEvents = buckets.reduce((s, b) => s + b.eventCount, 0);
+  const isLoading = sessionQ.isLoading || activityQ.isLoading;
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="px-5 py-4 border-b border-bg-border flex items-baseline gap-3">
+        <Link to={`/sessions/${encodeURIComponent(id)}`} className="text-fg-dim hover:text-accent">
+          <ArrowLeft className="w-4 h-4 inline" />
+        </Link>
+        <h1 className="text-lg font-bold">activity</h1>
+        <span className="text-sm text-fg-dim mono">{id.slice(0, 16)}</span>
+      </div>
+
+      {isLoading && <div className="p-6 text-fg-dim">loading…</div>}
+
+      {!isLoading && totalEvents === 0 && (
+        <div className="p-6 text-fg-dim">
+          no classified events yet for this session.
+        </div>
+      )}
+
+      {!isLoading && totalEvents > 0 && (
+        <>
+          <div className="px-5 py-4 grid grid-cols-2 md:grid-cols-4 gap-3 border-b border-bg-border">
+            <Stat label="categories" value={String(buckets.length)} />
+            <Stat label="events" value={String(totalEvents)} />
+            <Stat label="total cost" value={formatUSD(totalCost)} />
+            <Stat
+              label="span"
+              value={
+                chartData.length > 0
+                  ? `${chartData[0]!.bucket.slice(11)} – ${chartData[chartData.length - 1]!.bucket.slice(11)}`
+                  : "—"
+              }
+            />
+          </div>
+
+          <div className="p-5">
+            <div className="text-xs uppercase text-fg-muted mb-2">
+              events × category over time (1-min buckets)
+            </div>
+            <div
+              className="bg-bg-surface border border-bg-border rounded-lg p-3"
+              style={{ height: 320 }}
+            >
+              <ResponsiveContainer>
+                <BarChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#2b3139" />
+                  <XAxis dataKey="bucket" stroke="#7d8590" tick={{ fontSize: 10 }} />
+                  <YAxis stroke="#7d8590" tick={{ fontSize: 10 }} />
+                  <Tooltip
+                    contentStyle={{
+                      background: "#0b0d10",
+                      border: "1px solid #2b3139",
+                      fontSize: 11,
+                    }}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 11 }} />
+                  {categories.map((c) => (
+                    <Bar key={c} dataKey={c} stackId="cat" fill={colorFor(c)} />
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="px-5 pb-6">
+            <div className="text-xs uppercase text-fg-muted mb-2">
+              per-category summary
+            </div>
+            <table className="w-full text-sm">
+              <thead className="text-left text-xs uppercase text-fg-muted">
+                <tr>
+                  <th className="py-1">category</th>
+                  <th className="py-1">events</th>
+                  <th className="py-1">cost</th>
+                  <th className="py-1">% events</th>
+                  <th className="py-1">% cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {buckets.map((b) => (
+                  <tr key={b.category} className="mono text-xs border-b border-bg-border/30">
+                    <td className="py-1.5 flex items-center gap-2">
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-sm"
+                        style={{ background: colorFor(b.category) }}
+                      />
+                      {b.category}
+                    </td>
+                    <td className="py-1.5">{b.eventCount}</td>
+                    <td className="py-1.5">{formatUSD(b.costUsd)}</td>
+                    <td className="py-1.5 text-fg-dim">
+                      {totalEvents > 0
+                        ? `${((b.eventCount / totalEvents) * 100).toFixed(1)}%`
+                        : "—"}
+                    </td>
+                    <td className="py-1.5 text-fg-dim">
+                      {totalCost > 0
+                        ? `${((b.costUsd / totalCost) * 100).toFixed(1)}%`
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-bg-surface border border-bg-border rounded-md px-3 py-2">
+      <div className="text-[10px] uppercase text-fg-muted">{label}</div>
+      <div className="mono">{value}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
Linear: [AUR-269](https://linear.app/auraqu/issue/AUR-269)

## Summary

Visualizes the per-event activity classifier (AUR-264) data through two new lazy routes.

### \`/sessions/:id/activity\`
- Stacked bar of **events × category** in 1-min UTC buckets across the session's lifetime.
- Per-category summary table (events, cost, % of events, % of cost).
- Bucketed client-side from the session's events (which already carry \`details.category\`) so this didn't need a new time-series API.
- Empty state for sessions with zero classified events.

### \`/projects/:name/activity\`
- Pie of **events by category** + pie of **cost by category** side-by-side.
- Per-category breakdown table including the new **sessions touched** column.
- Empty state for unclassified projects.

### API extension
\`activityByProject\` now adds \`COUNT(DISTINCT session_id) AS sessions_touched\`. \`ActivityBucket\` interface gets an optional \`sessionsTouched\` field. The web client's \`EventDetails\` type also exposes the existing \`details.category\` field.

### Wiring
- Both pages are lazy-loaded (\`Suspense\` fallback), matching \`SessionTokens\`, \`Trends\`, \`SessionGraph\`.
- Nav links from \`Session.tsx\` and \`ProjectDetail.tsx\`.

## Acceptance criteria

- [x] New route \`/sessions/:id/activity\` rendering recharts stacked-bar over time + per-category cost summary.
- [x] New route \`/projects/:name/activity\` with pie + table including \`events / cost / sessions touched\`.
- [x] Both views handle the empty-data case gracefully.
- [x] Lazy-loaded in \`main.tsx\`.

## Test plan

- [x] \`npm run typecheck\` — clean (server)
- [x] \`web && npx tsc --noEmit\` — clean for new files (one pre-existing unused-var error in \`Logs.tsx\` left alone)
- [x] \`npm test\` — **369/369** pass (+1 new for \`sessionsTouched\`)
- [x] \`npm run build\` — server (tsup) + web (vite) both build