### PR TITLE
perf(serve): seed web timeline from SQLite; non-blocking startup (0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-05-26
+
+### Performance
+- **Web dashboard opens ~10x faster on large installs.** `serve` now seeds the
+  timeline from the SQLite store on startup (~0.5s to responsive) instead of
+  blocking the event loop on every session file's backfill. On a ~1 GB history
+  the first `/api/events` call dropped from ~12s to ~1.4s.
+- Adapters now start on the next tick (server answers requests first) and the
+  per-file backfill window shrank from 4 MB to 512 KB — history comes from the
+  store, so the backfill only needs to cover the gap since the last run.
+- `/api/events` `limit` is clamped to 2,000 to avoid multi-hundred-MB responses.
+
 ## [0.1.0] — 2026-05-03
 
 ### Added — v0.1 foundation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misha_misha/agentwatch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local-only observability + control plane for every AI coding agent on your machine. TUI live tail + browser dashboard on localhost. Unified timeline across Claude Code, Codex, Gemini CLI, Cursor, Hermes, OpenClaw — token + cost accounting, compaction + anomaly detection, SVG call graphs, diff attribution, agent-aware replay, MCP server mode, OpenTelemetry exporter. No cloud, no telemetry, no sign-in.",
   "type": "module",
   "author": "Misha Nefedov",

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -38,11 +38,12 @@ interface FileCursor {
 }
 
 /** When agentwatch restarts, each active session is backfilled from this
- *  many bytes behind EOF. 64 KB is ~20-50 turns — too small for heavy
- *  users who closed the TUI for a few hours. 4 MB covers ~days of a
- *  typical Claude session without blowing up memory (still bounded by
- *  MAX_EVENTS = 500 in the buffer). */
-const BACKFILL_BYTES = 4 * 1024 * 1024;
+ *  many bytes behind EOF — just enough to catch turns written while
+ *  agentwatch was off. History itself comes from the SQLite store (the TUI
+ *  and `serve` both seed their timeline from it), so this only needs to
+ *  cover the gap, not days. Keeping it small keeps startup from blocking
+ *  the event loop while every session file is re-read. */
+const BACKFILL_BYTES = 512 * 1024;
 
 export function startClaudeAdapter(sink: Emit): () => void {
   const normalized = normalizeSink(sink);

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -10,7 +10,7 @@ import { consumeSpawn } from "../util/spawn-tracker.js";
 import { readNewlineTerminatedLines } from "../util/jsonl-stream.js";
 import { createParseErrorTracker } from "../util/parse-errors.js";
 
-const BACKFILL_BYTES = 4 * 1024 * 1024;
+const BACKFILL_BYTES = 512 * 1024;
 
 export function codexSessionsDir(home: string = os.homedir()): string {
   return join(home, ".codex", "sessions");

--- a/src/adapters/openclaw.ts
+++ b/src/adapters/openclaw.ts
@@ -313,7 +313,7 @@ function processAudit(
 }
 
 /** Same backfill window as Claude adapter; see its comment. */
-const BACKFILL_BYTES = 4 * 1024 * 1024;
+const BACKFILL_BYTES = 512 * 1024;
 
 function streamLines(
   file: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -259,11 +259,29 @@ if (arg === "serve") {
   const classifiedSink = withClassifier(linkedSink);
   const sink = withClaudeHookDedup(classifiedSink);
   server.setHookSink(sink);
-  const adapters = startAllAdapters(sink, workspace);
+  // Seed the in-memory ring from the durable store so the web UI shows
+  // history immediately, instead of waiting on the adapters' file backfill
+  // (which, on a large install, can block the event loop for 10+ seconds).
+  // The store already holds everything prior runs ingested; dedup at the
+  // wrapSinkWithStore boundary handles any re-emit overlap.
+  if (store) {
+    try {
+      const seed = store.listRecentEvents({ limit: 5000, order: "desc" });
+      for (let i = seed.length - 1; i >= 0; i--) addEventToServer(server, seed[i]!);
+    } catch (err) {
+      process.stderr.write(`[agentwatch] ring seed skipped: ${String(err)}\n`);
+    }
+  }
+  process.stderr.write(`[agentwatch] serving ${server.url}\n`);
+  // Start adapters on the next tick so the server is already accepting
+  // requests (served from the seeded ring) before the file backfill runs.
+  let adapters: ReturnType<typeof startAllAdapters> = [];
+  setImmediate(() => {
+    adapters = startAllAdapters(sink, workspace);
+  });
   onShutdown(() => stopAllAdapters(adapters));
   onShutdown(() => server.stop());
   if (store) onShutdown(() => store?.close());
-  process.stderr.write(`[agentwatch] serving ${server.url}\n`);
   // Signal handling happens at the bottom of this file via the global
   // shutdown-hooks wiring; the serve path just registers its cleanup.
   await new Promise(() => undefined);

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -13,7 +13,7 @@ interface EventQuery {
 
 export function registerEventRoutes(app: FastifyInstance, events: AgentEvent[]): void {
   app.get<{ Querystring: EventQuery }>("/api/events", async (req) => {
-    const limit = clamp(parseInt(req.query.limit ?? "100", 10) || 100, 1, 50_000);
+    const limit = clamp(parseInt(req.query.limit ?? "100", 10) || 100, 1, 2_000);
     const beforeMs = req.query.before ? Date.parse(req.query.before) : null;
     // Buffer is stored oldest-first for O(1) append. Walk backwards to
     // build newest-first results without materializing a reversed copy.


### PR DESCRIPTION
## Summary
- The web dashboard took ~12s to open on large installs: `serve` started with an empty in-memory ring and waited on every adapter's synchronous file backfill, blocking the event loop ~10s.
- `serve` now seeds the ring from `store.listRecentEvents()` on startup (the TUI already did this) — data is available immediately.
- Adapters start on the next tick so the server answers requests before the backfill runs.
- Per-file backfill window 4MB → 512KB (history comes from the store now, backfill only covers the gap since last run).
- `/api/events` `limit` clamped 50000 → 2000 to avoid multi-hundred-MB responses.
- Bumps version to 0.1.1 + CHANGELOG.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 404 passed
- [x] `npm run build` OK
- [x] Smoke test on ~1GB real history: server responsive 10.8s → **0.46s**; first `/api/events?limit=100` 12.1s → **1.4s**