### PR TITLE
Daily maintainer agent: /maintain command + launchd runner

### DIFF
--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -1,0 +1,90 @@
+---
+description: Daily maintainer loop — triage issues and PRs, keep CI green, scan HN/Reddit for signal, propose (and only when approved, build) features
+---
+
+You are the agentwatch maintainer agent. You run headless once a day inside a
+dedicated clone of mishanefedov/agentwatch. Work through the steps below in
+order. Your final message is the day's report — make it a terse, factual log.
+
+If `$ARGUMENTS` contains `--dry-run`: perform steps 1–5 strictly read-only.
+No comments, no labels, no issues, no branches, no pushes. Report what you
+*would* have done.
+
+## Guardrails (read first, absolute)
+
+- **Never push to `main`.** All changes go through a branch + PR.
+- **Never merge or close a PR.** Never close an issue you didn't open.
+- **Local-only invariant of the product applies to you too:** the only network
+  you touch is GitHub (`gh`), `hn.algolia.com`, and `reddit.com`.
+- **No secrets:** never read, print, or commit tokens, keys, or `~/.claude`
+  credentials.
+- At most **one implementation PR per run**. Triage and signal-scanning are
+  unbounded; code changes are not.
+- Every PR must pass `npm test`, `npm run typecheck`, `npm run build` locally
+  before you open it, and must update `CHANGELOG.md` `[Unreleased]`.
+- Commit as the default git identity. No Co-Authored-By trailers. PR body
+  format: `## Summary` bullets + `## Test plan` checkboxes.
+- If anything looks off (dirty tree, unexpected branch, failing main), report
+  it and skip the affected step rather than forcing it.
+
+## 1. Sync
+
+```bash
+git checkout main && git pull --ff-only
+```
+
+## 2. Triage issues and PRs
+
+- `gh issue list --state open` and `gh pr list --state open`.
+- New issue with no maintainer response: reproduce/investigate briefly, reply
+  with findings and next steps, add labels (`bug`, `enhancement`, `question`).
+- Open PRs: check CI (`gh pr checks`), leave a short review comment if CI is
+  red or the diff violates AGENTS.md conventions. Do not merge.
+
+## 3. CI health
+
+- `gh run list --branch main --limit 5`. If main is red: diagnose, fix on a
+  branch (`ci-fix-<slug>`), open a PR. This counts as the run's one
+  implementation PR.
+
+## 4. Implement one approved item (at most one)
+
+- Find issues labeled `approved` (Michael's explicit go-ahead, given as a
+  label or an "approved" comment from mishanefedov).
+- Pick the smallest one. Branch (kebab-case slug), implement, test, PR with
+  `Closes #N`.
+- If none are approved, skip — do not pick work on your own initiative.
+
+## 5. Signal scan (HN + Reddit)
+
+Queries — run each against both sources, last 24h only:
+`agentwatch`, `ccusage`, `codeburn`, `agents view usage`, `claude code cost`,
+`ai agent observability`, `codex token usage`.
+
+- HN: `curl -s "https://hn.algolia.com/api/v1/search_by_date?query=<q>&numericFilters=created_at_i><24h-ago-epoch>"`
+- Reddit: `curl -s -A "agentwatch-maintainer" "https://www.reddit.com/r/ClaudeAI+LocalLLaMA+ChatGPTCoding/search.json?q=<q>&restrict_sr=on&sort=new&t=day"`
+
+From the hits, extract only: direct mentions of agentwatch, feature asks that
+agentwatch could satisfy, competitor releases/announcements, and complaints
+about agent cost/visibility. Ignore generic AI chatter.
+
+Post the day's digest as **one comment** on the pinned issue titled
+"📡 Signal digest" (create it once, labeled `signal`, if it doesn't exist).
+Format: date heading, then one bullet per finding with link + one-line
+takeaway. If there are zero findings, post nothing.
+
+## 6. Feature proposals from signal
+
+If a scraped finding is a concrete, repeatedly-requested capability that fits
+the roadmap (read `ROADMAP.md` §6 rejected directions before proposing):
+
+- Search existing issues first; comment on a duplicate rather than filing new.
+- File an issue labeled `scraped,proposal`: problem, evidence links, sketch of
+  implementation, estimated size.
+- **Do not implement it.** Implementation happens only after it gains the
+  `approved` label (step 4, a later run).
+
+## 7. Report
+
+End with: issues triaged (count + numbers), PRs reviewed, CI status, PR opened
+(URL or "none"), signal findings (count), proposals filed (numbers).

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ dist
 .env.local
 coverage
 .serena/
-.claude/
+.claude/*
+!.claude/commands/
 .openclaw/
 .agentwatch-bot/
 .gstack/

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -1,0 +1,77 @@
+# Maintainer agent
+
+A headless Claude Code session that runs once a day, keeps the repo healthy,
+and watches the outside world for signal. It is **not** part of the shipped
+product — it maintains this repo.
+
+## What it does per run
+
+1. Syncs `main`.
+2. Triages open issues (investigate, reply, label) and reviews open PRs
+   (CI status, convention violations). Never merges.
+3. If `main` CI is red, fixes it on a branch + PR.
+4. Implements at most **one** issue labeled `approved` — the human grants that
+   label; the agent never picks its own feature work.
+5. Scans Hacker News (Algolia API) and Reddit (r/ClaudeAI, r/LocalLLaMA,
+   r/ChatGPTCoding) for mentions, feature asks, and competitor moves from the
+   last 24 h; posts a digest comment on the pinned "📡 Signal digest" issue and
+   files `scraped,proposal` issues for concrete, roadmap-compatible ideas.
+
+The full instruction set (including guardrails) is the slash command at
+[`.claude/commands/maintain.md`](../.claude/commands/maintain.md).
+
+## Guardrails
+
+- Branch + PR only; never pushes `main`, never merges, never closes others'
+  issues.
+- One implementation PR per run, tests/typecheck/build green before opening.
+- Network surface: GitHub, `hn.algolia.com`, `reddit.com`. Nothing else.
+- Scraped ideas become *proposals*, not code — implementation requires the
+  human-granted `approved` label.
+
+## Install (macOS)
+
+```bash
+# 1. Dedicated clone (keeps your working copy out of the agent's hands)
+gh repo clone mishanefedov/agentwatch ~/IdeaProjects/agentwatch-maintainer
+
+# 2. launchd job — daily 07:30
+sed "s|\$HOME|$HOME|" ~/IdeaProjects/agentwatch-maintainer/scripts/maintainer/com.agentwatch.maintainer.plist \
+  > ~/Library/LaunchAgents/com.agentwatch.maintainer.plist
+launchctl load ~/Library/LaunchAgents/com.agentwatch.maintainer.plist
+
+# 3. Dry run to verify
+~/IdeaProjects/agentwatch-maintainer/scripts/maintainer/run.sh --dry-run
+tail -f ~/.agentwatch-maintainer/logs/$(date +%Y-%m-%d).log
+```
+
+Requires the `claude` CLI authenticated (subscription login works; runs count
+against your plan's rate limits) and `gh` authenticated with repo scope.
+
+Headless runs can't answer permission prompts, so the clone needs a
+`.claude/settings.local.json` allowlist (not committed; create it in the
+clone):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)", "Bash(gh:*)", "Bash(npm:*)", "Bash(node:*)",
+      "Bash(curl -s https://hn.algolia.com/*)",
+      "Bash(curl -s -A agentwatch-maintainer https://www.reddit.com/*)",
+      "WebFetch(domain:hn.algolia.com)", "WebFetch(domain:www.reddit.com)"
+    ]
+  }
+}
+```
+
+## Operate
+
+```bash
+launchctl start com.agentwatch.maintainer     # run now
+launchctl list | grep agentwatch              # status / last exit code
+launchctl unload ~/Library/LaunchAgents/com.agentwatch.maintainer.plist  # disable
+```
+
+Logs: `~/.agentwatch-maintainer/logs/YYYY-MM-DD.log` (one file per day).
+And yes — agentwatch's own cron surface watches this launchd job.

--- a/scripts/maintainer/com.agentwatch.maintainer.plist
+++ b/scripts/maintainer/com.agentwatch.maintainer.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentwatch.maintainer</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>$HOME/IdeaProjects/agentwatch-maintainer/scripts/maintainer/run.sh</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>7</integer>
+    <key>Minute</key>
+    <integer>30</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/com.agentwatch.maintainer.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/com.agentwatch.maintainer.err.log</string>
+</dict>
+</plist>

--- a/scripts/maintainer/run.sh
+++ b/scripts/maintainer/run.sh
@@ -1,0 +1,19 @@
+#!/bin/zsh
+# Daily maintainer-agent run. Installed via launchd (see
+# scripts/maintainer/com.agentwatch.maintainer.plist) or run manually:
+#   scripts/maintainer/run.sh [--dry-run]
+set -euo pipefail
+
+REPO="${AGENTWATCH_MAINTAINER_REPO:-$HOME/IdeaProjects/agentwatch-maintainer}"
+LOGDIR="$HOME/.agentwatch-maintainer/logs"
+mkdir -p "$LOGDIR"
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+cd "$REPO"
+git checkout -q main
+git pull -q --ff-only
+
+exec claude -p "/maintain $*" \
+  --permission-mode acceptEdits \
+  --max-turns 100 \
+  >>"$LOGDIR/$(date +%Y-%m-%d).log" 2>&1


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/maintain.md`: a guarded daily maintainer loop — issue/PR triage, CI health, at most one implementation PR per run (only for issues labeled `approved`), HN/Reddit signal scan posted to a pinned digest issue.
- Adds `scripts/maintainer/run.sh` + a launchd plist template for a daily 07:30 headless run in a dedicated clone.
- Adds `docs/maintainer.md`: install, guardrails, operations.
- Un-ignores `.claude/commands/` so the command ships with the repo; the rest of `.claude/` stays ignored.
- No product code touched; the agent's network surface is GitHub, hn.algolia.com, reddit.com only.

## Test plan
- [x] `zsh -n scripts/maintainer/run.sh` parses
- [x] `plutil -lint scripts/maintainer/com.agentwatch.maintainer.plist` passes
- [ ] Dry run (`run.sh --dry-run`) verified locally before merge