### PR TITLE
fix(mcp): real Gemini tool stats + session cost via shared translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+### Fixed
+- MCP `get_tool_usage_stats` and `get_session_cost` now return real per-tool
+  counts and token/cost breakdowns for Gemini sessions instead of zeroes. The
+  Gemini session-to-`AgentEvent` translation is now a shared pure function
+  (`translateGeminiDoc`) used by both the live adapter and the MCP server's
+  session parser, so there is one canonical implementation.
+
 ## [0.1.2] — 2026-05-26
 
 ### Performance

--- a/src/adapters/gemini.test.ts
+++ b/src/adapters/gemini.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractGeminiUsage } from "./gemini.js";
+import { extractGeminiUsage, translateGeminiDoc } from "./gemini.js";
 
 describe("extractGeminiUsage", () => {
   it("subtracts cached from total input to get fresh input", () => {
@@ -37,5 +37,106 @@ describe("extractGeminiUsage", () => {
         tokens: { input: 0, output: 0, cached: 0, thoughts: 0, tool: 0 },
       }),
     ).toBeNull();
+  });
+});
+
+describe("translateGeminiDoc", () => {
+  // Shape mirrors ~/.gemini/tmp/<project>/chats/session-<ts>-<hash>.json —
+  // this is the same document the MCP server's parseGeminiSession reads
+  // (single JSON, not JSONL) and the live adapter tails incrementally.
+  const doc = {
+    sessionId: "abc123",
+    kind: "main",
+    messages: [
+      {
+        id: "m1",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        type: "user",
+        content: [{ text: "read config.json and summarize it" }],
+      },
+      {
+        id: "m2",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        type: "gemini",
+        content: [{ text: "Reading the file now." }],
+        tokens: { input: 5000, output: 120, cached: 2000, thoughts: 30, tool: 0 },
+        toolCalls: [
+          {
+            id: "call-1",
+            name: "read_file",
+            args: { file_path: "config.json" },
+            result: [
+              { functionResponse: { response: { output: '{"ok":true}' } } },
+            ],
+          },
+          {
+            id: "call-2",
+            name: "run_shell_command",
+            args: { command: "ls -la" },
+            result: [
+              {
+                functionResponse: {
+                  response: { error: "permission denied" },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("translates prompt and response events in order", () => {
+    const events = translateGeminiDoc(doc, "session-abc", "myproject");
+    expect(events[0]).toMatchObject({
+      agent: "gemini",
+      type: "prompt",
+      sessionId: "session-abc",
+    });
+    expect(events[0].summary).toContain("config.json");
+    expect(events[1]).toMatchObject({ agent: "gemini", type: "response" });
+  });
+
+  it("translates inline toolCalls into per-tool events with results", () => {
+    const events = translateGeminiDoc(doc, "session-abc", "myproject");
+    const toolEvents = events.filter((e) => e.type !== "prompt" && e.type !== "response");
+    expect(toolEvents).toHaveLength(2);
+
+    const readEvent = toolEvents.find((e) => e.tool === "gemini:read_file");
+    expect(readEvent).toMatchObject({
+      type: "file_read",
+      path: "config.json",
+      sessionId: "session-abc",
+    });
+    expect(readEvent?.details?.toolResult).toContain("ok");
+    expect(readEvent?.details?.toolError).toBeUndefined();
+
+    const shellEvent = toolEvents.find((e) => e.tool === "gemini:run_shell_command");
+    expect(shellEvent).toMatchObject({
+      type: "shell_exec",
+      cmd: "ls -la",
+    });
+    expect(shellEvent?.details?.toolError).toBe(true);
+  });
+
+  it("carries usage + computed USD cost on the response event", () => {
+    const events = translateGeminiDoc(doc, "session-abc", "myproject");
+    const response = events.find((e) => e.type === "response");
+    expect(response?.details?.usage).toEqual({
+      input: 3000,
+      cacheCreate: 0,
+      cacheRead: 2000,
+      output: 150,
+    });
+    expect(response?.details?.model).toBe("gemini-2.5-pro");
+    // gemini-2.5-pro rates: input 1.25, cacheRead 0.31, output 10.0 per 1M.
+    const expectedCost =
+      (3000 * 1.25 + 2000 * 0.31 + 150 * 10.0) / 1_000_000;
+    expect(response?.details?.cost).toBeCloseTo(expectedCost, 10);
+  });
+
+  it("returns [] for a document with no messages", () => {
+    expect(translateGeminiDoc({}, "s", "p")).toEqual([]);
+    expect(translateGeminiDoc({ messages: [] }, "s", "p")).toEqual([]);
   });
 });

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -91,8 +91,8 @@ export function startGeminiAdapter(sink: Emit): () => void {
       if (!id || seen.has(id)) continue;
       seen.add(id);
 
-      const ev = translate(msg, sessionId, kind, project);
-      if (ev) {
+      const events = translateGeminiMessage(msg, sessionId, kind, project);
+      for (const ev of events) {
         const parent = pendingParentByFile.get(file);
         if (parent && !firstEventEmitted) {
           ev.details = { ...(ev.details ?? {}), parentSpawnId: parent };
@@ -100,17 +100,6 @@ export function startGeminiAdapter(sink: Emit): () => void {
           firstEventEmitted = true;
         }
         emit(ev);
-      }
-
-      // Each Gemini assistant message can carry an array of toolCalls,
-      // each already including the inline functionResponse. Emit one
-      // event per tool with the result attached — no pairing needed.
-      const toolCalls = msg.toolCalls;
-      if (Array.isArray(toolCalls)) {
-        for (const tc of toolCalls) {
-          const te = translateToolCall(tc, msg, sessionId, kind, project);
-          if (te) emit(te);
-        }
       }
     }
   };
@@ -122,6 +111,50 @@ export function startGeminiAdapter(sink: Emit): () => void {
   return () => {
     void watcher.close();
   };
+}
+
+/** Pure translation of an already-parsed Gemini session JSON document
+ *  (`{ sessionId, kind, messages: [...] }`) into AgentEvents. Shared by the
+ *  live adapter's per-file watch loop above and the MCP server's one-shot
+ *  `parseSession`, so there is exactly one place that understands Gemini's
+ *  session shape — no dedup-by-id here, this always translates every
+ *  message in the document. */
+export function translateGeminiDoc(
+  doc: Record<string, unknown>,
+  sessionId: string,
+  project: string,
+): AgentEvent[] {
+  const kind = typeof doc.kind === "string" ? doc.kind : "main";
+  const messages = Array.isArray(doc.messages) ? doc.messages : [];
+  const out: AgentEvent[] = [];
+  for (const m of messages) {
+    out.push(...translateGeminiMessage(m, sessionId, kind, project));
+  }
+  return out;
+}
+
+/** Translate one Gemini message plus its inline `toolCalls` into zero or
+ *  more AgentEvents, in emission order (the message's own event, if any,
+ *  followed by one event per tool call). */
+function translateGeminiMessage(
+  m: unknown,
+  sessionId: string,
+  kind: string,
+  project: string,
+): AgentEvent[] {
+  if (!m || typeof m !== "object") return [];
+  const msg = m as Record<string, unknown>;
+  const out: AgentEvent[] = [];
+  const ev = translate(msg, sessionId, kind, project);
+  if (ev) out.push(ev);
+  const toolCalls = msg.toolCalls;
+  if (Array.isArray(toolCalls)) {
+    for (const tc of toolCalls) {
+      const te = translateToolCall(tc, msg, sessionId, kind, project);
+      if (te) out.push(te);
+    }
+  }
+  return out;
 }
 
 function translate(

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseSession, type SessionRef } from "./server.js";
+
+/**
+ * AUR-3: `parseSession` is the shared read-path behind the
+ * `get_tool_usage_stats` and `get_session_cost` MCP tools. This exercises
+ * the Gemini branch specifically — it used to return `[]` unconditionally
+ * (see git history), which made both tools report honest-but-fake zeroes
+ * for every Gemini session. It now delegates to the same
+ * `translateGeminiDoc` pure function the live adapter uses, so real
+ * per-tool counts and real token/cost totals come out the other end.
+ */
+describe("parseSession — gemini", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeGeminiSession(doc: unknown): string {
+    dir = mkdtempSync(join(tmpdir(), "agentwatch-gemini-mcp-"));
+    const file = join(dir, "session-2026-01-01T00-00-00-abc123.json");
+    writeFileSync(file, JSON.stringify(doc));
+    return file;
+  }
+
+  const baseDoc = {
+    sessionId: "abc123",
+    kind: "main",
+    messages: [
+      {
+        id: "m1",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        type: "user",
+        content: [{ text: "list files and read the config" }],
+      },
+      {
+        id: "m2",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        type: "gemini",
+        content: [{ text: "On it." }],
+        tokens: { input: 4000, output: 200, cached: 1000, thoughts: 0, tool: 0 },
+        toolCalls: [
+          {
+            id: "call-1",
+            name: "run_shell_command",
+            args: { command: "ls" },
+            result: [{ functionResponse: { response: { output: "a.txt\nb.txt" } } }],
+          },
+          {
+            id: "call-2",
+            name: "read_file",
+            args: { file_path: "config.json" },
+            result: [{ functionResponse: { response: { output: "{}" } } }],
+          },
+          {
+            id: "call-3",
+            name: "run_shell_command",
+            args: { command: "cat missing.txt" },
+            result: [{ functionResponse: { response: { error: "not found" } } }],
+          },
+        ],
+      },
+    ],
+  };
+
+  function refFor(path: string): SessionRef {
+    return {
+      agent: "gemini",
+      sessionId: "session-abc",
+      project: "myproject",
+      path,
+      lastActivity: Date.now(),
+      sizeBytes: 0,
+    };
+  }
+
+  it("returns real per-tool counts (get_tool_usage_stats path)", () => {
+    const file = writeGeminiSession(baseDoc);
+    const events = parseSession(refFor(file));
+
+    const toolCounts = new Map<string, number>();
+    for (const e of events) {
+      if (!e.tool) continue;
+      toolCounts.set(e.tool, (toolCounts.get(e.tool) ?? 0) + 1);
+    }
+    expect(toolCounts.get("gemini:run_shell_command")).toBe(2);
+    expect(toolCounts.get("gemini:read_file")).toBe(1);
+
+    const errorCount = events.filter((e) => e.details?.toolError).length;
+    expect(errorCount).toBe(1);
+  });
+
+  it("returns real token breakdown + USD cost (get_session_cost path)", () => {
+    const file = writeGeminiSession(baseDoc);
+    const events = parseSession(refFor(file));
+
+    let totalCost = 0;
+    let input = 0;
+    let cacheRead = 0;
+    let cacheCreate = 0;
+    let output = 0;
+    for (const e of events) {
+      const d = e.details;
+      if (!d) continue;
+      if (d.cost) totalCost += d.cost;
+      if (d.usage) {
+        input += d.usage.input;
+        cacheRead += d.usage.cacheRead;
+        cacheCreate += d.usage.cacheCreate;
+        output += d.usage.output;
+      }
+    }
+
+    expect({ input, cacheCreate, cacheRead, output }).toEqual({
+      input: 3000,
+      cacheCreate: 0,
+      cacheRead: 1000,
+      output: 200,
+    });
+    expect(totalCost).toBeGreaterThan(0);
+    const expected = (3000 * 1.25 + 1000 * 0.31 + 200 * 10.0) / 1_000_000;
+    expect(totalCost).toBeCloseTo(expected, 10);
+  });
+
+  it("returns [] for an unreadable / malformed gemini session file", () => {
+    dir = mkdtempSync(join(tmpdir(), "agentwatch-gemini-mcp-"));
+    const file = join(dir, "session-broken.json");
+    writeFileSync(file, "{not valid json");
+    expect(parseSession(refFor(file))).toEqual([]);
+  });
+
+  it("returns [] when the gemini session file is missing", () => {
+    expect(
+      parseSession(refFor(join(tmpdir(), "agentwatch-does-not-exist.json"))),
+    ).toEqual([]);
+  });
+});
+
+describe("parseSession — claude-code and codex unaffected", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("still translates claude-code jsonl lines", () => {
+    dir = mkdtempSync(join(tmpdir(), "agentwatch-claude-mcp-"));
+    const file = join(dir, "session.jsonl");
+    const line = JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: {
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "hello" }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    });
+    writeFileSync(file, line + "\n");
+    const events = parseSession({
+      agent: "claude-code",
+      sessionId: "s1",
+      project: "p",
+      path: file,
+      lastActivity: Date.now(),
+      sizeBytes: 0,
+    });
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0].agent).toBe("claude-code");
+  });
+
+  it("still translates codex jsonl lines", () => {
+    dir = mkdtempSync(join(tmpdir(), "agentwatch-codex-mcp-"));
+    const file = join(dir, "rollout.jsonl");
+    const line = JSON.stringify({
+      type: "response_item",
+      ts: "2026-01-01T00:00:00.000Z",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ text: "hi" }],
+      },
+    });
+    writeFileSync(file, line + "\n");
+    const events = parseSession({
+      agent: "codex",
+      sessionId: "s1",
+      project: "p",
+      path: file,
+      lastActivity: Date.now(),
+      sizeBytes: 0,
+    });
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0].agent).toBe("codex");
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@ import Database from "better-sqlite3";
 import { claudeProjectsDir } from "../util/workspace.js";
 import { codexSessionsDir, translateCodexLine } from "../adapters/codex.js";
 import { translateClaudeLine } from "../adapters/claude-code.js";
+import { translateGeminiDoc } from "../adapters/gemini.js";
 import { translateSession as translateOpenClawLine } from "../adapters/openclaw.js";
 import {
   translateHermesMessage,
@@ -37,7 +38,7 @@ import { VERSION } from "../util/version.js";
 
 type McpAgent = "claude-code" | "codex" | "gemini" | "openclaw" | "hermes";
 
-interface SessionRef {
+export interface SessionRef {
   agent: McpAgent;
   sessionId: string;
   project: string;
@@ -338,16 +339,9 @@ function openHermesDb(path: string) {
 /** Read a session, translate every line via the relevant adapter,
  *  and return AgentEvents. Unreadable / malformed lines are silently
  *  skipped. */
-function parseSession(s: SessionRef): AgentEvent[] {
+export function parseSession(s: SessionRef): AgentEvent[] {
   if (s.agent === "hermes") return parseHermesSession(s);
-  if (s.agent === "gemini") {
-    // Gemini sessions are single-JSON not JSONL, and we don't yet
-    // translate them to AgentEvents for stats purposes. Return empty
-    // so get_tool_usage_stats / get_session_cost produce honest zeroes
-    // rather than fake data. Raw content still reachable via
-    // get_session_events.
-    return [];
-  }
+  if (s.agent === "gemini") return parseGeminiSession(s);
   const raw = safeReadFile(s.path);
   if (!raw) return [];
   const out: AgentEvent[] = [];
@@ -371,6 +365,25 @@ function parseSession(s: SessionRef): AgentEvent[] {
     if (e) out.push(e);
   }
   return out;
+}
+
+/** Gemini sessions are a single JSON document, not JSONL — parse it once
+ *  and hand off to the same pure translator the live adapter uses. */
+function parseGeminiSession(s: SessionRef): AgentEvent[] {
+  const raw = safeReadFile(s.path);
+  if (!raw) return [];
+  let doc: unknown;
+  try {
+    doc = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!doc || typeof doc !== "object") return [];
+  return translateGeminiDoc(
+    doc as Record<string, unknown>,
+    s.sessionId,
+    s.project,
+  );
 }
 
 function parseHermesSession(s: SessionRef): AgentEvent[] {


### PR DESCRIPTION
## Summary
- `get_tool_usage_stats` and `get_session_cost` were returning honest-but-fake zeroes for Gemini sessions because `src/mcp/server.ts::parseSession()` short-circuited the Gemini branch to `[]`.
- Extracted the live Gemini adapter's message + inline-`toolCalls` translation into a new exported pure function, `translateGeminiDoc()`, in `src/adapters/gemini.ts` — no duplicate translation logic.
- `parseSession()` now parses the Gemini session's single JSON document and calls `translateGeminiDoc()`, same as `translateClaudeLine`/`translateCodexLine` are already reused for the Claude/Codex branches.
- The live adapter's per-file watch loop now calls the same shared `translateGeminiMessage()` helper instead of inlining the translate + toolCalls loop, preserving its existing dedup-by-id and parent-spawn-attach behavior exactly.
- Claude and Codex MCP paths are untouched.

## Test plan
- [x] `npm test` — 414 tests pass, including new coverage in `src/adapters/gemini.test.ts` (`translateGeminiDoc`: prompt/response ordering, tool call translation with results/errors, usage + USD cost) and new `src/mcp/server.test.ts` (`parseSession` gemini path: per-tool counts, token/cost breakdown, malformed/missing file handling, plus a regression check that claude-code/codex paths still translate).
- [x] `npm run typecheck` — passes.
- [x] `npm run build` — passes (server + web).
- [x] Updated `CHANGELOG.md` `[Unreleased]`.

Closes #3