### PR TITLE
cron surface v1: launchd agents + crontab discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+### Added
+- Scheduled-jobs surface (`/cron`) now discovers macOS launchd user agents
+  (`~/Library/LaunchAgents/*.plist`, with live `launchctl` health) and the
+  user crontab (`crontab -l`) alongside existing OpenClaw cron/heartbeats,
+  and badges jobs whose command mentions a known AI agent binary.
+
 ## [0.1.2] — 2026-05-26
 
 ### Performance

--- a/docs/features/scheduled-jobs.md
+++ b/docs/features/scheduled-jobs.md
@@ -1,0 +1,71 @@
+# Scheduled jobs
+
+## Contract
+
+**GOAL:** One read-only surface listing every background/scheduled agent job on the machine — OpenClaw cron + heartbeats, macOS launchd user agents, and the user crontab.
+**USER_VALUE:** Answer "what's running unattended on this box, and is it healthy?" without hand-checking three different subsystems (`openclaw cron list`, `launchctl list`, `crontab -l`).
+**COUNTERFACTUAL:** A launchd agent silently dies (`LastExitStatus` != 0) or a stray crontab entry keeps firing an old agent script, and nobody notices until it causes damage or the human stumbles on it by accident.
+
+## What it does
+
+The `/cron` route (`GET /api/cron`, `web/src/routes/Cron.tsx`) surfaces
+four independent sources of scheduled/background agent activity on one
+page:
+
+- **OpenClaw cron jobs** — `~/.openclaw/cron/jobs.json` via
+  `src/util/openclaw-cron.ts`.
+- **OpenClaw heartbeats** — `HEARTBEAT.md` per workspace via
+  `src/util/openclaw-heartbeat.ts`.
+- **launchd user agents** (macOS only) — every `~/Library/LaunchAgents/*.plist`
+  via `src/util/launchd-agents.ts`, joined with live health from
+  `launchctl list <label>`.
+- **crontab** — the current user's `crontab -l` via `src/util/crontab.ts`.
+
+Jobs whose program/arguments/command mention a known AI agent binary
+(`claude`, `codex`, `gemini`, `openclaw`, `agentwatch` — see
+`src/util/agent-mention.ts`) are flagged with an `agent` badge so
+agent-related scheduled work stands out from ordinary system cron/launchd
+noise.
+
+## How to invoke
+
+Open the `/cron` (scheduled) route in the web UI. Data refetches every
+10s (`refetchInterval` in `Cron.tsx`).
+
+## Inputs
+
+- `readCronJobs()` / `readAllHeartbeats()` — existing OpenClaw parsers,
+  unchanged.
+- `readLaunchdAgents()` — parses each plist (XML in-process; binary
+  plists normalized via `plutil -convert xml1 -o - <file>`), extracts
+  `Label`, `Program`/`ProgramArguments`, and derives a human schedule
+  string from `StartCalendarInterval` / `StartInterval` / `RunAtLoad`.
+  Joins `launchctl list <label>` for `PID` (running) and
+  `LastExitStatus`. Returns `[]` on non-macOS.
+- `readCrontab()` — runs `crontab -l`, parses each non-comment,
+  non-env-assignment line into `{ schedule, command }`. A non-zero exit
+  (no crontab installed) is treated as an empty list, not an error.
+
+## Outputs
+
+`GET /api/cron` → `{ jobs, heartbeats, launchd, crontab, scheduledEvents }`.
+Existing fields (`jobs`, `heartbeats`, `scheduledEvents`) are unchanged
+for backward compatibility; `launchd` and `crontab` are additive.
+
+## Failure modes
+
+- **Non-macOS host**: `launchd` is always `[]`; the UI shows "No launchd
+  user agents detected."
+- **No crontab installed**: `crontab` is `[]`; the UI shows "No user
+  crontab installed."
+- **launchd job not loaded / launchctl unreachable**: `loaded: false,
+  running: false` rather than a thrown error — job still listed with its
+  plist-derived schedule, just marked not running.
+- **Corrupt or unreadable plist**: that file is skipped; the rest of the
+  discovery continues.
+
+## Interactions
+
+- Read-only, local-only: never writes to crontab or plists.
+  `plutil -convert xml1 -o -` writes to stdout only (`-o -`), never back
+  to the file. `crontab -l` and `launchctl list` are the only shell-outs.

--- a/src/server/routes/cron.ts
+++ b/src/server/routes/cron.ts
@@ -2,12 +2,16 @@ import type { FastifyInstance } from "fastify";
 import type { AgentEvent } from "../../schema.js";
 import { readCronJobs } from "../../util/openclaw-cron.js";
 import { readAllHeartbeats } from "../../util/openclaw-heartbeat.js";
+import { readLaunchdAgents } from "../../util/launchd-agents.js";
+import { readCrontab } from "../../util/crontab.js";
 
 export function registerCronRoutes(app: FastifyInstance, events: AgentEvent[]): void {
   app.get("/api/cron", async () => {
     return {
       jobs: readCronJobs(),
       heartbeats: readAllHeartbeats(),
+      launchd: readLaunchdAgents(),
+      crontab: readCrontab(),
       // events is oldest-first; reverse the last 200 to show newest first.
       scheduledEvents: events
         .filter((e) => e.details?.scheduled)

--- a/src/util/agent-mention.ts
+++ b/src/util/agent-mention.ts
@@ -1,0 +1,25 @@
+/**
+ * Cheap substring heuristic for "does this scheduled-job command look
+ * agent-related" — used to badge launchd agents / crontab lines that
+ * likely invoke an AI coding agent, so they stand out from ordinary
+ * system cron/launchd noise on the scheduled-jobs surface.
+ *
+ * Deliberately a substring match, not the precise argv-rule matching in
+ * `agent-call.ts` (which exists for a different job: turning a shell
+ * command into structured agent-to-agent call metadata for the call
+ * graph). Here we only need a yes/no badge.
+ */
+
+export const KNOWN_AGENT_KEYWORDS = [
+  "claude",
+  "codex",
+  "gemini",
+  "openclaw",
+  "agentwatch",
+] as const;
+
+export function mentionsKnownAgent(text: string | undefined): boolean {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return KNOWN_AGENT_KEYWORDS.some((kw) => lower.includes(kw));
+}

--- a/src/util/crontab.test.ts
+++ b/src/util/crontab.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseCrontab, readCrontab } from "./crontab.js";
+
+describe("parseCrontab", () => {
+  it("parses a standard 5-field schedule + command", () => {
+    const entries = parseCrontab("23 8 * * * /Users/me/script.sh >> /tmp/log 2>&1\n");
+    expect(entries).toEqual([
+      {
+        schedule: "23 8 * * *",
+        command: "/Users/me/script.sh >> /tmp/log 2>&1",
+        raw: "23 8 * * * /Users/me/script.sh >> /tmp/log 2>&1",
+        agentTag: false,
+      },
+    ]);
+  });
+
+  it("parses @keyword shorthand schedules", () => {
+    const entries = parseCrontab("@daily /Users/me/backup.sh\n");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ schedule: "@daily", command: "/Users/me/backup.sh" });
+  });
+
+  it("skips comments and blank lines", () => {
+    const text = "# a comment\n\n   \n23 8 * * * /bin/true\n";
+    expect(parseCrontab(text)).toHaveLength(1);
+  });
+
+  it("skips env-var assignment lines", () => {
+    const text = 'PATH=/usr/bin:/bin\nMAILTO=""\n0 * * * * /bin/true\n';
+    const entries = parseCrontab(text);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.command).toBe("/bin/true");
+  });
+
+  it("flags commands that mention a known agent", () => {
+    const entries = parseCrontab("0 9 * * * /usr/local/bin/claude -p 'daily digest'\n");
+    expect(entries[0]!.agentTag).toBe(true);
+  });
+
+  it("does not flag ordinary system commands", () => {
+    const entries = parseCrontab("0 3 * * * /usr/bin/find /tmp -mtime +7 -delete\n");
+    expect(entries[0]!.agentTag).toBe(false);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(parseCrontab("")).toEqual([]);
+  });
+});
+
+describe("readCrontab", () => {
+  it("calls `crontab -l` and parses the result", () => {
+    const fakeExec = vi.fn((cmd: string, args: string[]) => {
+      expect(cmd).toBe("crontab");
+      expect(args).toEqual(["-l"]);
+      return "0 9 * * * /bin/true\n";
+    });
+    expect(readCrontab(fakeExec)).toHaveLength(1);
+  });
+
+  it("returns [] when crontab -l exits non-zero (no crontab installed)", () => {
+    const fakeExec = vi.fn(() => {
+      throw new Error("crontab: no crontab for user");
+    });
+    expect(readCrontab(fakeExec)).toEqual([]);
+  });
+});

--- a/src/util/crontab.ts
+++ b/src/util/crontab.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from "node:child_process";
+import { mentionsKnownAgent } from "./agent-mention.js";
+
+/**
+ * Read-only discovery of the current user's crontab (`crontab -l`).
+ *
+ * `crontab -l` exits non-zero (and prints "no crontab for <user>" on
+ * stderr) when no crontab is installed — that's treated as an empty
+ * list, not an error. We never write to the crontab (`crontab -e` /
+ * `crontab <file>` are never invoked here).
+ */
+
+export type ExecFn = (cmd: string, args: string[]) => string;
+
+const realExec: ExecFn = (cmd, args) => execFileSync(cmd, args, { encoding: "utf8" });
+
+export interface CrontabEntry {
+  /** Raw schedule field(s), e.g. `23 8 * * *` or `@daily`. */
+  schedule: string;
+  command: string;
+  raw: string;
+  agentTag: boolean;
+}
+
+const ENV_LINE = /^[A-Za-z_][A-Za-z0-9_]*\s*=/;
+// 5 whitespace-separated schedule fields, or an `@keyword` shorthand,
+// followed by the command.
+const CRON_LINE = /^((?:\S+\s+){4}\S+|@\S+)\s+(.+)$/;
+
+/** Parse `crontab -l` output text into structured entries. Skips
+ *  comments (`#`) and env-var assignment lines (`FOO=bar`). */
+export function parseCrontab(text: string): CrontabEntry[] {
+  const out: CrontabEntry[] = [];
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    if (ENV_LINE.test(line)) continue;
+    const m = CRON_LINE.exec(line);
+    if (!m) continue;
+    const schedule = m[1]!;
+    const command = m[2]!;
+    out.push({ schedule, command, raw: line, agentTag: mentionsKnownAgent(command) });
+  }
+  return out;
+}
+
+/** Read + parse the current user's crontab. Returns [] when there is no
+ *  crontab installed, `crontab` isn't available, or the command fails
+ *  for any other reason. */
+export function readCrontab(exec: ExecFn = realExec): CrontabEntry[] {
+  let out: string;
+  try {
+    out = exec("crontab", ["-l"]);
+  } catch {
+    return [];
+  }
+  return parseCrontab(out);
+}

--- a/src/util/launchd-agents.test.ts
+++ b/src/util/launchd-agents.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  discoverLaunchAgentFiles,
+  getLaunchdHealth,
+  parsePlistXml,
+  readLaunchdAgents,
+  readPlistFile,
+} from "./launchd-agents.js";
+
+const XML_HEADER = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">`;
+
+function wrap(dict: string): string {
+  return `${XML_HEADER}\n<dict>\n${dict}\n</dict>\n</plist>`;
+}
+
+function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const orig = process.platform;
+  Object.defineProperty(process, "platform", { value: platform });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, "platform", { value: orig });
+  }
+}
+
+const tmpDirs: string[] = [];
+function mkTmpDir(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    const d = tmpDirs.pop()!;
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("parsePlistXml", () => {
+  it("parses scalars, arrays, and nested dicts", () => {
+    const xml = wrap(`
+      <key>Label</key>
+      <string>com.example.agent</string>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <false/>
+      <key>ProgramArguments</key>
+      <array>
+        <string>/usr/bin/node</string>
+        <string>/path/to/script.js</string>
+      </array>
+      <key>StartCalendarInterval</key>
+      <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>23</integer>
+      </dict>
+    `);
+    expect(parsePlistXml(xml)).toMatchObject({
+      Label: "com.example.agent",
+      RunAtLoad: true,
+      KeepAlive: false,
+      ProgramArguments: ["/usr/bin/node", "/path/to/script.js"],
+      StartCalendarInterval: { Hour: 8, Minute: 23 },
+    });
+  });
+
+  it("returns {} when there's no top-level dict", () => {
+    expect(parsePlistXml("<plist/>")).toEqual({});
+  });
+});
+
+describe("readPlistFile", () => {
+  it("parses XML plists in-process without shelling out", () => {
+    const tmp = mkTmpDir("plist-xml-");
+    const file = path.join(tmp, "com.example.plist");
+    fs.writeFileSync(file, wrap(`<key>Label</key><string>com.example.agent</string>`));
+    const fakeExec = vi.fn(() => {
+      throw new Error("should not shell out for a text plist");
+    });
+    expect(readPlistFile(file, fakeExec)).toMatchObject({ Label: "com.example.agent" });
+    expect(fakeExec).not.toHaveBeenCalled();
+  });
+
+  it("shells out to plutil -convert xml1 for binary-encoded plists", () => {
+    const tmp = mkTmpDir("plist-bin-");
+    const file = path.join(tmp, "com.example.plist");
+    fs.writeFileSync(file, Buffer.concat([Buffer.from("bplist00", "utf8"), Buffer.from([0, 1, 2, 3])]));
+    const fakeExec = vi.fn((cmd: string, args: string[]) => {
+      expect(cmd).toBe("plutil");
+      expect(args).toEqual(["-convert", "xml1", "-o", "-", file]);
+      return wrap(`<key>Label</key><string>com.example.agent</string>`);
+    });
+    expect(readPlistFile(file, fakeExec)).toMatchObject({ Label: "com.example.agent" });
+    expect(fakeExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when the file doesn't exist", () => {
+    expect(readPlistFile("/tmp/does-not-exist-agentwatch.plist")).toBeNull();
+  });
+
+  it("returns null when plutil fails", () => {
+    const tmp = mkTmpDir("plist-bin-fail-");
+    const file = path.join(tmp, "bad.plist");
+    fs.writeFileSync(file, Buffer.from("bplist00\x00\x01"));
+    const fakeExec = vi.fn(() => {
+      throw new Error("plutil: corrupt");
+    });
+    expect(readPlistFile(file, fakeExec)).toBeNull();
+  });
+});
+
+describe("getLaunchdHealth", () => {
+  it("reports running with pid + lastExitStatus from launchctl list output", () => {
+    withPlatform("darwin", () => {
+      const out = `{\n\t"PID" = 12600;\n\t"LastExitStatus" = 9;\n\t"Label" = "com.example";\n};`;
+      const fakeExec = vi.fn(() => out);
+      expect(getLaunchdHealth("com.example", fakeExec)).toEqual({
+        loaded: true,
+        running: true,
+        pid: 12600,
+        lastExitStatus: 9,
+      });
+    });
+  });
+
+  it("treats a non-zero exit (job not loaded) as not running, not an error", () => {
+    withPlatform("darwin", () => {
+      const fakeExec = vi.fn(() => {
+        throw new Error('Could not find service "com.missing" in domain for port');
+      });
+      expect(getLaunchdHealth("com.missing", fakeExec)).toEqual({ loaded: false, running: false });
+    });
+  });
+
+  it("returns not-loaded on non-macOS without calling exec", () => {
+    withPlatform("linux", () => {
+      const fakeExec = vi.fn(() => "should not be called");
+      expect(getLaunchdHealth("com.example", fakeExec)).toEqual({ loaded: false, running: false });
+      expect(fakeExec).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("readLaunchdAgents", () => {
+  it("discovers plists, derives schedule + agent tag, and joins launchctl health", () => {
+    withPlatform("darwin", () => {
+      const home = mkTmpDir("home-");
+      const dir = path.join(home, "Library", "LaunchAgents");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "com.example.claude-daily.plist"),
+        wrap(`
+          <key>Label</key>
+          <string>com.example.claude-daily</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>/usr/local/bin/claude</string>
+            <string>run</string>
+          </array>
+          <key>StartCalendarInterval</key>
+          <dict>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+          </dict>
+        `),
+      );
+      const fakeExec = vi.fn((cmd: string) => {
+        if (cmd === "launchctl") return `{ "PID" = 500; "LastExitStatus" = 0; };`;
+        throw new Error(`unexpected exec: ${cmd}`);
+      });
+      const agents = readLaunchdAgents(home, fakeExec);
+      expect(agents).toHaveLength(1);
+      expect(agents[0]).toMatchObject({
+        label: "com.example.claude-daily",
+        program: "/usr/local/bin/claude",
+        schedule: "daily at 08:00",
+        scheduleKind: "calendar",
+        running: true,
+        pid: 500,
+        lastExitStatus: 0,
+        agentTag: true,
+      });
+    });
+  });
+
+  it("describes StartInterval and RunAtLoad-only and manual schedules", () => {
+    withPlatform("darwin", () => {
+      const home = mkTmpDir("home-schedules-");
+      const dir = path.join(home, "Library", "LaunchAgents");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "com.example.interval.plist"),
+        wrap(`
+          <key>Label</key>
+          <string>com.example.interval</string>
+          <key>Program</key>
+          <string>/usr/bin/backup</string>
+          <key>StartInterval</key>
+          <integer>300</integer>
+        `),
+      );
+      fs.writeFileSync(
+        path.join(dir, "com.example.onload.plist"),
+        wrap(`
+          <key>Label</key>
+          <string>com.example.onload</string>
+          <key>Program</key>
+          <string>/usr/bin/watcher</string>
+          <key>RunAtLoad</key>
+          <true/>
+        `),
+      );
+      fs.writeFileSync(
+        path.join(dir, "com.example.manual.plist"),
+        wrap(`
+          <key>Label</key>
+          <string>com.example.manual</string>
+          <key>Program</key>
+          <string>/usr/bin/manual-thing</string>
+        `),
+      );
+      const fakeExec = vi.fn((cmd: string) => {
+        if (cmd === "launchctl") throw new Error("not loaded");
+        throw new Error(`unexpected exec: ${cmd}`);
+      });
+      const agents = readLaunchdAgents(home, fakeExec);
+      const byLabel = Object.fromEntries(agents.map((a) => [a.label, a]));
+      expect(byLabel["com.example.interval"]).toMatchObject({
+        schedule: "every 5m",
+        scheduleKind: "interval",
+        agentTag: false,
+      });
+      expect(byLabel["com.example.onload"]).toMatchObject({
+        schedule: "on load",
+        scheduleKind: "onload",
+      });
+      expect(byLabel["com.example.manual"]).toMatchObject({
+        schedule: "manual",
+        scheduleKind: "unknown",
+        loaded: false,
+        running: false,
+      });
+    });
+  });
+
+  it("returns [] on non-macOS regardless of fixture files", () => {
+    withPlatform("linux", () => {
+      expect(readLaunchdAgents("/tmp/whatever-agentwatch-home")).toEqual([]);
+    });
+  });
+});
+
+describe("discoverLaunchAgentFiles", () => {
+  it("returns [] on non-macOS", () => {
+    withPlatform("linux", () => {
+      expect(discoverLaunchAgentFiles("/tmp/whatever-agentwatch-home")).toEqual([]);
+    });
+  });
+
+  it("returns [] when the LaunchAgents directory doesn't exist", () => {
+    withPlatform("darwin", () => {
+      const home = mkTmpDir("home-empty-");
+      expect(discoverLaunchAgentFiles(home)).toEqual([]);
+    });
+  });
+});

--- a/src/util/launchd-agents.ts
+++ b/src/util/launchd-agents.ts
@@ -1,0 +1,306 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { humanizeMs } from "./openclaw-cron.js";
+import { mentionsKnownAgent } from "./agent-mention.js";
+
+/**
+ * Read-only discovery of macOS launchd user agents at
+ * `~/Library/LaunchAgents/*.plist`.
+ *
+ * Plists on disk are either XML text or Apple's binary plist format
+ * (magic bytes `bplist00`). We parse XML plists in-process (no deps —
+ * a minimal tokenizer covers the subset of plist types launchd agents
+ * actually use: dict/array/string/integer/real/bool). Binary plists are
+ * normalized to XML by shelling out to `plutil -convert xml1 -o -
+ * <file>` (read-only; never `-o <file>` in place).
+ *
+ * Health comes from `launchctl list <label>`: a PID in the output means
+ * the job is currently running; `LastExitStatus` is the last exit code
+ * recorded for on-demand jobs. A non-zero exit from `launchctl list`
+ * (job not loaded / launchd unavailable) is treated as "not loaded",
+ * not an error.
+ *
+ * Everything here is guarded to return [] on non-macOS platforms.
+ */
+
+export type ExecFn = (cmd: string, args: string[]) => string;
+
+const realExec: ExecFn = (cmd, args) => execFileSync(cmd, args, { encoding: "utf8" });
+
+export interface LaunchdAgent {
+  label: string;
+  path: string;
+  program?: string;
+  arguments?: string[];
+  schedule: string;
+  scheduleKind: "calendar" | "interval" | "onload" | "unknown";
+  loaded: boolean;
+  running: boolean;
+  pid?: number;
+  lastExitStatus?: number;
+  agentTag: boolean;
+}
+
+/** List every `*.plist` under `~/Library/LaunchAgents/`. [] on non-macOS
+ *  or when the directory doesn't exist. */
+export function discoverLaunchAgentFiles(home: string = os.homedir()): string[] {
+  if (process.platform !== "darwin") return [];
+  const dir = path.join(home, "Library", "LaunchAgents");
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(".plist"))
+    .map((e) => path.join(dir, e.name))
+    .sort();
+}
+
+const BINARY_PLIST_MAGIC = "bplist00";
+
+/** Read + parse one plist file into a plain object. Shells out to
+ *  `plutil -convert xml1 -o -` only when the file is binary-encoded. */
+export function readPlistFile(
+  file: string,
+  exec: ExecFn = realExec,
+): Record<string, unknown> | null {
+  let buf: Buffer;
+  try {
+    buf = fs.readFileSync(file);
+  } catch {
+    return null;
+  }
+  let xml: string;
+  if (buf.subarray(0, 8).toString("utf8") === BINARY_PLIST_MAGIC) {
+    try {
+      xml = exec("plutil", ["-convert", "xml1", "-o", "-", file]);
+    } catch {
+      return null;
+    }
+  } else {
+    xml = buf.toString("utf8");
+  }
+  try {
+    return parsePlistXml(xml);
+  } catch {
+    return null;
+  }
+}
+
+/** Query `launchctl list <label>` for run health. Treats any non-zero
+ *  exit (job not loaded, launchd unreachable) as "not loaded". */
+export function getLaunchdHealth(
+  label: string,
+  exec: ExecFn = realExec,
+): { loaded: boolean; running: boolean; pid?: number; lastExitStatus?: number } {
+  if (process.platform !== "darwin") return { loaded: false, running: false };
+  let out: string;
+  try {
+    out = exec("launchctl", ["list", label]);
+  } catch {
+    return { loaded: false, running: false };
+  }
+  const pidMatch = out.match(/"PID"\s*=\s*(\d+);/);
+  const exitMatch = out.match(/"LastExitStatus"\s*=\s*(-?\d+);/);
+  const pid = pidMatch ? Number(pidMatch[1]) : undefined;
+  return {
+    loaded: true,
+    running: pid !== undefined,
+    pid,
+    lastExitStatus: exitMatch ? Number(exitMatch[1]) : undefined,
+  };
+}
+
+/** Discover + parse every launch agent plist, joined with launchctl
+ *  health. Returns [] on non-macOS. */
+export function readLaunchdAgents(
+  home: string = os.homedir(),
+  exec: ExecFn = realExec,
+): LaunchdAgent[] {
+  if (process.platform !== "darwin") return [];
+  const files = discoverLaunchAgentFiles(home);
+  const out: LaunchdAgent[] = [];
+  for (const file of files) {
+    const raw = readPlistFile(file, exec);
+    if (!raw) continue;
+    const label = typeof raw.Label === "string" ? raw.Label : path.basename(file, ".plist");
+    const programArguments = Array.isArray(raw.ProgramArguments)
+      ? raw.ProgramArguments.filter((x): x is string => typeof x === "string")
+      : undefined;
+    const program = typeof raw.Program === "string" ? raw.Program : programArguments?.[0];
+    const { schedule, scheduleKind } = describeSchedule(raw);
+    const health = getLaunchdHealth(label, exec);
+    const mentionText = [program, ...(programArguments ?? [])].filter(Boolean).join(" ");
+    out.push({
+      label,
+      path: file,
+      program,
+      arguments: programArguments,
+      schedule,
+      scheduleKind,
+      loaded: health.loaded,
+      running: health.running,
+      pid: health.pid,
+      lastExitStatus: health.lastExitStatus,
+      agentTag: mentionsKnownAgent(mentionText),
+    });
+  }
+  return out;
+}
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function describeSchedule(
+  raw: Record<string, unknown>,
+): { schedule: string; scheduleKind: LaunchdAgent["scheduleKind"] } {
+  if (raw.StartCalendarInterval !== undefined) {
+    const intervals = Array.isArray(raw.StartCalendarInterval)
+      ? raw.StartCalendarInterval
+      : [raw.StartCalendarInterval];
+    const parts = intervals
+      .filter((iv): iv is Record<string, unknown> => !!iv && typeof iv === "object")
+      .map(describeCalendarInterval);
+    return { schedule: parts.length ? parts.join("; ") : "calendar", scheduleKind: "calendar" };
+  }
+  if (typeof raw.StartInterval === "number") {
+    return { schedule: `every ${humanizeMs(raw.StartInterval * 1000)}`, scheduleKind: "interval" };
+  }
+  if (raw.RunAtLoad === true) {
+    return { schedule: "on load", scheduleKind: "onload" };
+  }
+  return { schedule: "manual", scheduleKind: "unknown" };
+}
+
+function describeCalendarInterval(iv: Record<string, unknown>): string {
+  const hour = typeof iv.Hour === "number" ? iv.Hour : undefined;
+  const minute = typeof iv.Minute === "number" ? iv.Minute : undefined;
+  const weekday = typeof iv.Weekday === "number" ? iv.Weekday : undefined;
+  const day = typeof iv.Day === "number" ? iv.Day : undefined;
+  const time =
+    hour !== undefined || minute !== undefined
+      ? `${String(hour ?? 0).padStart(2, "0")}:${String(minute ?? 0).padStart(2, "0")}`
+      : undefined;
+  if (weekday !== undefined) {
+    return `weekly on ${WEEKDAYS[weekday] ?? weekday}${time ? ` at ${time}` : ""}`;
+  }
+  if (day !== undefined) {
+    return `monthly on day ${day}${time ? ` at ${time}` : ""}`;
+  }
+  if (time) return `daily at ${time}`;
+  return "calendar";
+}
+
+// ---------------------------------------------------------------------------
+// Minimal plist XML parser — covers dict/array/string/integer/real/bool,
+// which is the full set launchd agent plists use. Not a general XML parser.
+
+interface PlistToken {
+  type:
+    | "key"
+    | "string"
+    | "integer"
+    | "real"
+    | "data"
+    | "date"
+    | "true"
+    | "false"
+    | "dict-open"
+    | "dict-close"
+    | "array-open"
+    | "array-close";
+  value?: string;
+}
+
+const TOKEN_RE =
+  /<key>([\s\S]*?)<\/key>|<string>([\s\S]*?)<\/string>|<integer>([\s\S]*?)<\/integer>|<real>([\s\S]*?)<\/real>|<data>([\s\S]*?)<\/data>|<date>([\s\S]*?)<\/date>|<true\s*\/>|<false\s*\/>|<dict>|<\/dict>|<array>|<\/array>/g;
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function tokenize(xml: string): PlistToken[] {
+  const tokens: PlistToken[] = [];
+  let m: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((m = TOKEN_RE.exec(xml))) {
+    const full = m[0];
+    if (full.startsWith("<key>")) tokens.push({ type: "key", value: decodeXmlEntities(m[1] ?? "") });
+    else if (full.startsWith("<string>")) tokens.push({ type: "string", value: decodeXmlEntities(m[2] ?? "") });
+    else if (full.startsWith("<integer>")) tokens.push({ type: "integer", value: m[3] });
+    else if (full.startsWith("<real>")) tokens.push({ type: "real", value: m[4] });
+    else if (full.startsWith("<data>")) tokens.push({ type: "data", value: m[5] });
+    else if (full.startsWith("<date>")) tokens.push({ type: "date", value: m[6] });
+    else if (full.startsWith("<true")) tokens.push({ type: "true" });
+    else if (full.startsWith("<false")) tokens.push({ type: "false" });
+    else if (full === "<dict>") tokens.push({ type: "dict-open" });
+    else if (full === "</dict>") tokens.push({ type: "dict-close" });
+    else if (full === "<array>") tokens.push({ type: "array-open" });
+    else if (full === "</array>") tokens.push({ type: "array-close" });
+  }
+  return tokens;
+}
+
+function parseValue(tokens: PlistToken[], i: number): [unknown, number] {
+  const t = tokens[i];
+  if (!t) return [undefined, i + 1];
+  switch (t.type) {
+    case "string":
+      return [t.value ?? "", i + 1];
+    case "integer":
+    case "real":
+      return [Number(t.value), i + 1];
+    case "true":
+      return [true, i + 1];
+    case "false":
+      return [false, i + 1];
+    case "data":
+    case "date":
+      return [t.value ?? "", i + 1];
+    case "array-open": {
+      const arr: unknown[] = [];
+      let j = i + 1;
+      while (tokens[j] && tokens[j]!.type !== "array-close") {
+        const [v, next] = parseValue(tokens, j);
+        arr.push(v);
+        j = next;
+      }
+      return [arr, j + 1];
+    }
+    case "dict-open": {
+      const obj: Record<string, unknown> = {};
+      let j = i + 1;
+      while (tokens[j] && tokens[j]!.type !== "dict-close") {
+        const keyTok = tokens[j]!;
+        if (keyTok.type !== "key") {
+          j += 1;
+          continue;
+        }
+        const key = keyTok.value ?? "";
+        const [v, next] = parseValue(tokens, j + 1);
+        obj[key] = v;
+        j = next;
+      }
+      return [obj, j + 1];
+    }
+    default:
+      return [undefined, i + 1];
+  }
+}
+
+/** Parse plist XML text into a plain object. Exported for tests; also
+ *  used internally by `readPlistFile`. */
+export function parsePlistXml(xml: string): Record<string, unknown> {
+  const tokens = tokenize(xml);
+  if (tokens.length === 0 || tokens[0]!.type !== "dict-open") return {};
+  const [value] = parseValue(tokens, 0);
+  return (value ?? {}) as Record<string, unknown>;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -168,7 +168,14 @@ export const api = {
 
   permissions: () => getJson<any>("/api/permissions"),
 
-  cron: () => getJson<{ jobs: any[]; heartbeats: any[]; scheduledEvents: AgentEvent[] }>("/api/cron"),
+  cron: () =>
+    getJson<{
+      jobs: any[];
+      heartbeats: any[];
+      launchd: any[];
+      crontab: any[];
+      scheduledEvents: AgentEvent[];
+    }>("/api/cron"),
 
   config: (kind: "budgets" | "anomaly" | "triggers") =>
     getJson<{ kind: string; path: string; value: any; defaults: any }>(`/api/config/${kind}`),

--- a/web/src/routes/Cron.tsx
+++ b/web/src/routes/Cron.tsx
@@ -1,13 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../lib/api";
 import { formatDateTime } from "../lib/format";
-import { Clock, Heart, Calendar } from "lucide-react";
+import { Clock, Heart, Calendar, Server, Terminal } from "lucide-react";
+
+function AgentBadge() {
+  return (
+    <span className="ml-2 mono text-[10px] px-1.5 py-0.5 rounded bg-accent/20 text-accent border border-accent/40">
+      agent
+    </span>
+  );
+}
 
 export function CronPage() {
   const q = useQuery({ queryKey: ["cron"], queryFn: api.cron, refetchInterval: 10_000 });
   if (q.isLoading) return <div className="p-6 text-fg-dim">loading…</div>;
   const jobs = q.data?.jobs ?? [];
   const heartbeats = q.data?.heartbeats ?? [];
+  const launchd = q.data?.launchd ?? [];
+  const crontab = q.data?.crontab ?? [];
   const scheduledEvents = q.data?.scheduledEvents ?? [];
 
   return (
@@ -74,6 +84,74 @@ export function CronPage() {
                   <td className="py-1.5 pr-4 text-fg-dim">{h.agentId ?? "—"}</td>
                   <td className="py-1.5 pr-4 text-fg-dim">{h.lastHeartbeatAt ? formatDateTime(h.lastHeartbeatAt) : "—"}</td>
                   <td className="py-1.5 text-fg-dim truncate max-w-md">{h.filePath ?? h.file ?? ""}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section className="p-5 border-t border-bg-border">
+        <div className="flex items-center gap-2 mb-3">
+          <Server className="w-4 h-4 text-accent" />
+          <h2 className="font-bold">launchd agents</h2>
+          <span className="text-xs text-fg-dim">{launchd.length}</span>
+        </div>
+        {launchd.length === 0 && <div className="text-sm text-fg-dim">No launchd user agents detected.</div>}
+        {launchd.length > 0 && (
+          <table className="w-full text-sm">
+            <thead className="text-left text-xs uppercase text-fg-muted">
+              <tr>
+                <th className="py-1 pr-4">label</th>
+                <th className="py-1 pr-4">schedule</th>
+                <th className="py-1 pr-4">program</th>
+                <th className="py-1 pr-4">status</th>
+                <th className="py-1">last exit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {launchd.map((a: any) => (
+                <tr key={a.label} className="border-b border-bg-border/30 mono text-xs">
+                  <td className="py-1.5 pr-4">
+                    {a.label}
+                    {a.agentTag && <AgentBadge />}
+                  </td>
+                  <td className="py-1.5 pr-4 text-fg-dim">{a.schedule ?? "—"}</td>
+                  <td className="py-1.5 pr-4 text-fg-dim truncate max-w-xs">{a.program ?? "—"}</td>
+                  <td className="py-1.5 pr-4 text-fg-dim">
+                    {a.running ? <span className="text-ok">running (pid {a.pid})</span> : a.loaded ? "loaded" : "not loaded"}
+                  </td>
+                  <td className="py-1.5 text-fg-dim">{a.lastExitStatus ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section className="p-5 border-t border-bg-border">
+        <div className="flex items-center gap-2 mb-3">
+          <Terminal className="w-4 h-4 text-accent" />
+          <h2 className="font-bold">crontab</h2>
+          <span className="text-xs text-fg-dim">{crontab.length}</span>
+        </div>
+        {crontab.length === 0 && <div className="text-sm text-fg-dim">No user crontab installed.</div>}
+        {crontab.length > 0 && (
+          <table className="w-full text-sm">
+            <thead className="text-left text-xs uppercase text-fg-muted">
+              <tr>
+                <th className="py-1 pr-4">schedule</th>
+                <th className="py-1">command</th>
+              </tr>
+            </thead>
+            <tbody>
+              {crontab.map((c: any, i: number) => (
+                <tr key={i} className="border-b border-bg-border/30 mono text-xs">
+                  <td className="py-1.5 pr-4 whitespace-nowrap">{c.schedule}</td>
+                  <td className="py-1.5 text-fg-dim truncate max-w-xl">
+                    {c.command}
+                    {c.agentTag && <AgentBadge />}
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
- Extends the scheduled-jobs surface beyond OpenClaw-only: `GET /api/cron` now also returns `launchd` (macOS `~/Library/LaunchAgents/*.plist`, joined with `launchctl list <label>` health) and `crontab` (`crontab -l`), read-only, alongside the existing `jobs`/`heartbeats`/`scheduledEvents` fields (unchanged for compatibility).
- New util modules mirror `openclaw-cron.ts`'s shape: `src/util/launchd-agents.ts` (in-process plist XML parser, `plutil -convert xml1 -o -` fallback for binary plists, schedule derived from `StartCalendarInterval`/`StartInterval`/`RunAtLoad`) and `src/util/crontab.ts` (parses schedule + command per line, skips comments/env lines, treats a non-zero exit / no-crontab as empty).
- Jobs whose program/arguments/command mention a known AI agent (`claude`, `codex`, `gemini`, `openclaw`, `agentwatch` — `src/util/agent-mention.ts`) get an `agent` badge in the new "launchd agents" and "crontab" sections of `web/src/routes/Cron.tsx`, styled to match the existing OpenClaw sections.
- Added `docs/features/scheduled-jobs.md` (GOAL/USER_VALUE/COUNTERFACTUAL contract for the whole surface, since none existed for cron yet) and a CHANGELOG entry.
- Both platforms are guarded: non-macOS returns `launchd: []`; no crontab installed returns `crontab: []`. All shell-outs (`plutil`, `launchctl`, `crontab -l`) are read-only.

## Test plan
- [x] `npm test` — 428 tests pass, including new `src/util/launchd-agents.test.ts` (14 tests: plist parsing, binary-vs-XML dispatch with mocked `plutil`, `launchctl` health mocked for running/not-loaded, schedule kinds, platform guard) and `src/util/crontab.test.ts` (9 tests: schedule parsing, `@keyword` shorthand, comment/env-line skipping, agent-mention flagging, mocked `crontab -l`)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — server + web build clean
- [x] Manually verified against real local data: booted the server, `curl`'d `/api/cron` (all 5 keys present, real launchd agents + real crontab entry returned), and loaded `/cron` in a headless browser — screenshot confirms the new "launchd agents" and "crontab" sections render with matching typography/table style and correct `agent` badges on agent-related jobs