### PR TITLE
Cursor: SQLite adapter for composer sessions + prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+### Added
+- **Cursor adapter now reads real activity**, not just config. It reads
+  `composer.composerData` and `aiService.prompts` from every
+  `workspaceStorage/*/state.vscdb` on the machine, emitting one `session_start`
+  per composer session (with lines added/removed) and `prompt` events anchored
+  to the composer's `createdAt`. Cursor doesn't persist tool calls, token
+  usage, or cost to disk, so those stay absent — documented in
+  `docs/features/agent-detection.md`.
+
 ## [0.1.2] — 2026-05-26
 
 ### Performance

--- a/docs/features/agent-detection.md
+++ b/docs/features/agent-detection.md
@@ -25,7 +25,7 @@ or just recognizing it.
 |---|---|---|
 | Claude Code | `~/.claude/projects/` | ✓ |
 | OpenClaw | `~/.openclaw/` | ✓ |
-| Cursor | `~/.cursor/` | ✓ (config-level) |
+| Cursor | `~/.cursor/` or a `workspaceStorage/*/state.vscdb` with activity | ✓ |
 | Gemini CLI | `~/.gemini/` | ✓ |
 | Codex | `~/.codex/` | not yet |
 | Aider | `~/.aider.chat.history.md` or `~/.aider.input.history` | not yet |
@@ -56,6 +56,33 @@ session file: https://github.com/mishanefedov/agentwatch/issues/new
 
 Agent side panel inside the TUI applies the same `●` (green) /
 `●` (yellow) / `○` (gray) color code.
+
+## Cursor: what's captured vs. what isn't
+
+`src/adapters/cursor.ts` reads two independent surfaces, both read-only:
+
+- **Config** (`~/.cursor/mcp.json`, `cli-config.json`, `ide_state.json`,
+  `.cursorrules` / `.cursor/rules/*.mdc`) — watched for changes only.
+- **Activity** — every `workspaceStorage/*/state.vscdb` under
+  `~/Library/Application Support/Cursor/User/` (macOS) or
+  `~/.config/Cursor/User/` (Linux). Each is a VS Code-style
+  `ItemTable(key, value)` SQLite db. We read two keys:
+  - `composer.composerData` → one `session_start` event per composer
+    session, timestamped at its `createdAt`, with `totalLinesAdded` /
+    `totalLinesRemoved` carried in `details.linesChanged`.
+  - `aiService.prompts` → one `prompt` event per entry, anchored to the
+    most-recently-created composer's `createdAt` in that db (there is no
+    per-prompt timestamp and no stored link from a prompt to a
+    composerId, so this is a rough-but-real approximation, not exact).
+
+  These two config surfaces are independent: a Cursor GUI user with no
+  `~/.cursor` directory (never used the CLI) still gets activity events
+  as long as a `state.vscdb` with a composer session exists.
+
+- **What's permanently absent**: tool_call/tool_result, per-turn token
+  usage, and cost. Cursor doesn't write any of that to disk — it isn't a
+  parsing gap, there is nothing on disk to parse. Don't expect Cursor
+  sessions to show token/cost numbers the way Claude Code or Codex do.
 
 ## Failure modes
 

--- a/src/adapters/cursor.integration.test.ts
+++ b/src/adapters/cursor.integration.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { startCursorAdapter } from "./cursor.js";
+import { openStore, type EventStore } from "../store/sqlite.js";
 import type { AgentEvent } from "../schema.js";
 
 // Mirrors VS Code / Cursor's real ItemTable shape: a single key/value
@@ -166,5 +167,69 @@ describe("startCursorAdapter — SQLite activity (integration)", () => {
     );
     expect(newPrompt).toBeDefined();
     expect(newPrompt?.sessionId).toBe("c1");
+  });
+
+  describe("store-level idempotence across repeated backfills (restart simulation)", () => {
+    let store: EventStore;
+    let storeDir: string;
+
+    beforeEach(() => {
+      storeDir = mkdtempSync(join(tmpdir(), "cursor-adapter-store-"));
+      store = openStore({ dbPath: join(storeDir, "events.db") });
+    });
+
+    afterEach(() => {
+      store.close();
+      rmSync(storeDir, { recursive: true, force: true });
+    });
+
+    it("re-inserting the same full backfill (as on a second process boot) does not grow row count", () => {
+      const wsDir = join(storageRoot, "restart-sim");
+      mkdirSync(wsDir, { recursive: true });
+      seedWorkspaceDb(join(wsDir, "state.vscdb"), {
+        composers: {
+          allComposers: [
+            { composerId: "c1", createdAt: 1_700_000_000_000, totalLinesAdded: 5, totalLinesRemoved: 1 },
+            { composerId: "c2", createdAt: 1_700_000_100_000, totalLinesAdded: 8, totalLinesRemoved: 2 },
+          ],
+        },
+        prompts: [
+          { text: "first prompt" },
+          { text: "second prompt" },
+          { text: "third prompt" },
+        ],
+      });
+
+      // Boot 1: adapter starts fresh (no prior in-memory state), backfills
+      // everything currently on disk, then the process "restarts" (stop()
+      // discards all in-memory seen/emitted tracking).
+      const boot1Events: AgentEvent[] = [];
+      const boot1 = startCursorAdapter(tmpDir, (e) => boot1Events.push(e));
+      boot1.stop();
+      expect(boot1Events.length).toBeGreaterThan(0);
+      store.insertMany(boot1Events);
+      const countAfterBoot1 = store.stats().events;
+
+      // Boot 2: a brand-new adapter instance (fresh Maps), same on-disk
+      // db, same rows still present -> re-emits the identical backfill.
+      const boot2Events: AgentEvent[] = [];
+      const boot2 = startCursorAdapter(tmpDir, (e) => boot2Events.push(e));
+      boot2.stop();
+      expect(boot2Events.length).toBe(boot1Events.length);
+      store.insertMany(boot2Events);
+      const countAfterBoot2 = store.stats().events;
+
+      expect(countAfterBoot2).toBe(countAfterBoot1);
+
+      // The sessions_upsert_on_event_insert trigger must not have kept
+      // bumping event_count for sessions that only ever ignored inserts.
+      // Prompts anchor to the newest composer (c2); c1 only gets its own
+      // session_start.
+      const sessions = store.listSessions({ agent: "cursor" });
+      const c1 = sessions.find((s) => s.sessionId === "c1");
+      const c2 = sessions.find((s) => s.sessionId === "c2");
+      expect(c1?.eventCount).toBe(1);
+      expect(c2?.eventCount).toBe(4); // session_start + 3 prompts
+    });
   });
 });

--- a/src/adapters/cursor.integration.test.ts
+++ b/src/adapters/cursor.integration.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { startCursorAdapter } from "./cursor.js";
+import type { AgentEvent } from "../schema.js";
+
+// Mirrors VS Code / Cursor's real ItemTable shape: a single key/value
+// table where `value` holds a JSON blob per key.
+const ITEM_TABLE_SCHEMA = `
+CREATE TABLE ItemTable (
+  key TEXT UNIQUE ON CONFLICT REPLACE,
+  value BLOB
+);
+`;
+
+function seedWorkspaceDb(
+  dbPath: string,
+  opts: { composers?: unknown; prompts?: unknown } = {},
+): void {
+  const db = new Database(dbPath);
+  db.exec(ITEM_TABLE_SCHEMA);
+  const insert = db.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)");
+  if (opts.composers !== undefined) {
+    insert.run("composer.composerData", JSON.stringify(opts.composers));
+  }
+  if (opts.prompts !== undefined) {
+    insert.run("aiService.prompts", JSON.stringify(opts.prompts));
+  }
+  db.close();
+}
+
+describe("startCursorAdapter — SQLite activity (integration)", () => {
+  let tmpDir: string;
+  let storageRoot: string;
+  let cursorDir: string;
+  let events: AgentEvent[];
+  let stop: (() => void) | null;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "cursor-adapter-"));
+    storageRoot = join(tmpDir, "workspaceStorage");
+    cursorDir = join(tmpDir, "dot-cursor"); // deliberately absent-by-default
+    mkdirSync(storageRoot, { recursive: true });
+    process.env.CURSOR_WORKSPACE_STORAGE_DIR = storageRoot;
+    process.env.CURSOR_DIR = cursorDir; // does not exist -> installed:false
+    events = [];
+    stop = null;
+  });
+
+  afterEach(() => {
+    if (stop) stop();
+    delete process.env.CURSOR_WORKSPACE_STORAGE_DIR;
+    delete process.env.CURSOR_DIR;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("no-ops when neither ~/.cursor nor any workspaceStorage db exists", () => {
+    rmSync(storageRoot, { recursive: true, force: true });
+    const result = startCursorAdapter(tmpDir, (e) => events.push(e));
+    stop = result.stop;
+    expect(result.status.installed).toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  it("backfills composer sessions + prompts on boot even with no ~/.cursor", () => {
+    const wsDir = join(storageRoot, "abc123");
+    mkdirSync(wsDir, { recursive: true });
+    seedWorkspaceDb(join(wsDir, "state.vscdb"), {
+      composers: {
+        allComposers: [
+          {
+            composerId: "composer-1",
+            createdAt: 1_700_000_000_000,
+            totalLinesAdded: 20,
+            totalLinesRemoved: 5,
+            isArchived: false,
+          },
+        ],
+      },
+      prompts: [{ text: "add a login page", commandType: 4 }, { text: "fix the bug" }],
+    });
+
+    const result = startCursorAdapter(tmpDir, (e) => events.push(e));
+    stop = result.stop;
+
+    const sessionStarts = events.filter((e) => e.type === "session_start" && e.agent === "cursor");
+    const prompts = events.filter((e) => e.type === "prompt" && e.agent === "cursor");
+
+    expect(sessionStarts).toHaveLength(1);
+    expect(sessionStarts[0]?.sessionId).toBe("composer-1");
+    expect(sessionStarts[0]?.details?.linesChanged).toEqual({ added: 20, removed: 5 });
+
+    expect(prompts).toHaveLength(2);
+    expect(prompts.map((p) => p.details?.fullText)).toEqual([
+      "add a login page",
+      "fix the bug",
+    ]);
+    // Prompts have no native timestamp — anchored to the composer's createdAt.
+    for (const p of prompts) {
+      expect(p.sessionId).toBe("composer-1");
+      expect(p.ts).toBe(new Date(1_700_000_000_000).toISOString());
+    }
+  });
+
+  it("skips prompt events (but still emits composer sessions) when there are no composers to anchor to", () => {
+    const wsDir = join(storageRoot, "no-composer");
+    mkdirSync(wsDir, { recursive: true });
+    seedWorkspaceDb(join(wsDir, "state.vscdb"), {
+      prompts: [{ text: "orphan prompt" }],
+    });
+
+    const result = startCursorAdapter(tmpDir, (e) => events.push(e));
+    stop = result.stop;
+
+    expect(events.filter((e) => e.type === "prompt")).toEqual([]);
+    expect(events.filter((e) => e.type === "session_start")).toEqual([]);
+  });
+
+  it("aggregates across multiple workspaceStorage directories", () => {
+    const ws1 = join(storageRoot, "ws1");
+    const ws2 = join(storageRoot, "ws2");
+    mkdirSync(ws1, { recursive: true });
+    mkdirSync(ws2, { recursive: true });
+    seedWorkspaceDb(join(ws1, "state.vscdb"), {
+      composers: { allComposers: [{ composerId: "ws1-composer", createdAt: 1_700_000_000_000 }] },
+    });
+    seedWorkspaceDb(join(ws2, "state.vscdb"), {
+      composers: { allComposers: [{ composerId: "ws2-composer", createdAt: 1_700_000_100_000 }] },
+    });
+
+    const result = startCursorAdapter(tmpDir, (e) => events.push(e));
+    stop = result.stop;
+
+    const ids = events
+      .filter((e) => e.type === "session_start")
+      .map((e) => e.sessionId)
+      .sort();
+    expect(ids).toEqual(["ws1-composer", "ws2-composer"]);
+  });
+
+  it("picks up a new composer + prompt appended AFTER the adapter starts", { timeout: 10_000 }, async () => {
+    const wsDir = join(storageRoot, "live");
+    mkdirSync(wsDir, { recursive: true });
+    const dbPath = join(wsDir, "state.vscdb");
+    seedWorkspaceDb(dbPath, {
+      composers: { allComposers: [{ composerId: "c1", createdAt: 1_700_000_000_000 }] },
+      prompts: [{ text: "first prompt" }],
+    });
+
+    const result = startCursorAdapter(tmpDir, (e) => events.push(e));
+    stop = result.stop;
+    events.length = 0;
+
+    const db = new Database(dbPath);
+    db.prepare("UPDATE ItemTable SET value = ? WHERE key = 'aiService.prompts'").run(
+      JSON.stringify([{ text: "first prompt" }, { text: "second prompt" }]),
+    );
+    db.close();
+
+    await new Promise((r) => setTimeout(r, 3_000));
+
+    const newPrompt = events.find(
+      (e) => e.type === "prompt" && e.details?.fullText === "second prompt",
+    );
+    expect(newPrompt).toBeDefined();
+    expect(newPrompt?.sessionId).toBe("c1");
+  });
+});

--- a/src/adapters/cursor.test.ts
+++ b/src/adapters/cursor.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseCursorComposerEntries,
+  parseCursorPromptEntries,
+  translateCursorComposer,
+  translateCursorPrompt,
+  type CursorComposerEntry,
+} from "./cursor.js";
+
+describe("parseCursorComposerEntries", () => {
+  it("reads entries from the { allComposers: [...] } wrapper shape", () => {
+    const entries = parseCursorComposerEntries(
+      JSON.stringify({
+        allComposers: [
+          {
+            composerId: "c-1",
+            createdAt: 1_700_000_000_000,
+            totalLinesAdded: 12,
+            totalLinesRemoved: 3,
+            isArchived: false,
+          },
+        ],
+      }),
+    );
+    expect(entries).toEqual([
+      {
+        composerId: "c-1",
+        createdAt: 1_700_000_000_000,
+        totalLinesAdded: 12,
+        totalLinesRemoved: 3,
+        isArchived: false,
+      },
+    ]);
+  });
+
+  it("also accepts a bare array shape", () => {
+    const entries = parseCursorComposerEntries(
+      JSON.stringify([{ composerId: "c-2", createdAt: 1_700_000_001_000 }]),
+    );
+    expect(entries).toEqual([
+      {
+        composerId: "c-2",
+        createdAt: 1_700_000_001_000,
+        totalLinesAdded: 0,
+        totalLinesRemoved: 0,
+        isArchived: false,
+      },
+    ]);
+  });
+
+  it("drops entries missing composerId or createdAt", () => {
+    const entries = parseCursorComposerEntries(
+      JSON.stringify({
+        allComposers: [
+          { composerId: "no-created-at" },
+          { createdAt: 1 },
+          { composerId: "ok", createdAt: 1 },
+        ],
+      }),
+    );
+    expect(entries.map((e) => e.composerId)).toEqual(["ok"]);
+  });
+
+  it("returns [] for malformed JSON instead of throwing", () => {
+    expect(parseCursorComposerEntries("not json")).toEqual([]);
+    expect(parseCursorComposerEntries("")).toEqual([]);
+  });
+});
+
+describe("parseCursorPromptEntries", () => {
+  it("reads {text, commandType} entries", () => {
+    const prompts = parseCursorPromptEntries(
+      JSON.stringify([
+        { text: "fix the bug", commandType: 4 },
+        { text: "add a test" },
+      ]),
+    );
+    expect(prompts).toEqual([
+      { text: "fix the bug", commandType: 4 },
+      { text: "add a test", commandType: undefined },
+    ]);
+  });
+
+  it("drops entries with no usable text", () => {
+    const prompts = parseCursorPromptEntries(
+      JSON.stringify([{ text: "" }, { commandType: 1 }, { text: "keep me" }]),
+    );
+    expect(prompts).toEqual([{ text: "keep me", commandType: undefined }]);
+  });
+
+  it("returns [] for a non-array or malformed value", () => {
+    expect(parseCursorPromptEntries(JSON.stringify({ not: "an array" }))).toEqual([]);
+    expect(parseCursorPromptEntries("{broken")).toEqual([]);
+  });
+});
+
+const BASE_COMPOSER: CursorComposerEntry = {
+  composerId: "composer-abcdef12",
+  createdAt: 1_700_000_000_000,
+  totalLinesAdded: 40,
+  totalLinesRemoved: 10,
+  isArchived: false,
+};
+
+describe("translateCursorComposer", () => {
+  it("emits a session_start tagged agent=cursor with linesChanged + timestamp", () => {
+    const e = translateCursorComposer(BASE_COMPOSER, "/db/state.vscdb");
+    expect(e.agent).toBe("cursor");
+    expect(e.type).toBe("session_start");
+    expect(e.sessionId).toBe("composer-abcdef12");
+    expect(e.ts).toBe(new Date(BASE_COMPOSER.createdAt).toISOString());
+    expect(e.details?.linesChanged).toEqual({ added: 40, removed: 10 });
+    expect(e.summary).toContain("+40/-10");
+    expect(e.summary).not.toContain("archived");
+  });
+
+  it("tags archived composers in the summary", () => {
+    const e = translateCursorComposer({ ...BASE_COMPOSER, isArchived: true }, "/db");
+    expect(e.summary).toContain("[archived]");
+  });
+});
+
+describe("translateCursorPrompt", () => {
+  it("anchors the prompt's ts + sessionId to the given composer", () => {
+    const e = translateCursorPrompt({ text: "refactor the parser" }, BASE_COMPOSER, "/db");
+    expect(e.agent).toBe("cursor");
+    expect(e.type).toBe("prompt");
+    expect(e.sessionId).toBe(BASE_COMPOSER.composerId);
+    expect(e.ts).toBe(new Date(BASE_COMPOSER.createdAt).toISOString());
+    expect(e.details?.fullText).toBe("refactor the parser");
+    expect(e.summary).toBe("refactor the parser");
+  });
+
+  it("truncates long prompt text into a single-line summary under 140 chars", () => {
+    const long = "x".repeat(500);
+    const e = translateCursorPrompt({ text: long }, BASE_COMPOSER, "/db");
+    expect(e.summary?.length).toBeLessThanOrEqual(140);
+    expect(e.summary?.endsWith("...")).toBe(true);
+    expect(e.details?.fullText).toBe(long);
+  });
+});

--- a/src/adapters/cursor.test.ts
+++ b/src/adapters/cursor.test.ts
@@ -118,11 +118,18 @@ describe("translateCursorComposer", () => {
     const e = translateCursorComposer({ ...BASE_COMPOSER, isArchived: true }, "/db");
     expect(e.summary).toContain("[archived]");
   });
+
+  it("derives a deterministic id from the composerId (stable across repeated backfills)", () => {
+    const a = translateCursorComposer(BASE_COMPOSER, "/db/state.vscdb");
+    const b = translateCursorComposer(BASE_COMPOSER, "/db/state.vscdb");
+    expect(a.id).toBe(b.id);
+    expect(a.id).toBe(`cursor-${BASE_COMPOSER.composerId}`);
+  });
 });
 
 describe("translateCursorPrompt", () => {
   it("anchors the prompt's ts + sessionId to the given composer", () => {
-    const e = translateCursorPrompt({ text: "refactor the parser" }, BASE_COMPOSER, "/db");
+    const e = translateCursorPrompt({ text: "refactor the parser" }, 0, BASE_COMPOSER, "/db");
     expect(e.agent).toBe("cursor");
     expect(e.type).toBe("prompt");
     expect(e.sessionId).toBe(BASE_COMPOSER.composerId);
@@ -133,9 +140,22 @@ describe("translateCursorPrompt", () => {
 
   it("truncates long prompt text into a single-line summary under 140 chars", () => {
     const long = "x".repeat(500);
-    const e = translateCursorPrompt({ text: long }, BASE_COMPOSER, "/db");
+    const e = translateCursorPrompt({ text: long }, 0, BASE_COMPOSER, "/db");
     expect(e.summary?.length).toBeLessThanOrEqual(140);
     expect(e.summary?.endsWith("...")).toBe(true);
     expect(e.details?.fullText).toBe(long);
+  });
+
+  it("derives a deterministic id from composerId + array index (stable across repeated backfills)", () => {
+    const a = translateCursorPrompt({ text: "fix the bug" }, 3, BASE_COMPOSER, "/db");
+    const b = translateCursorPrompt({ text: "fix the bug" }, 3, BASE_COMPOSER, "/db");
+    expect(a.id).toBe(b.id);
+    expect(a.id).toBe(`cursor-${BASE_COMPOSER.composerId}-p3`);
+  });
+
+  it("gives different prompts at different indices different ids", () => {
+    const a = translateCursorPrompt({ text: "one" }, 0, BASE_COMPOSER, "/db");
+    const b = translateCursorPrompt({ text: "two" }, 1, BASE_COMPOSER, "/db");
+    expect(a.id).not.toBe(b.id);
   });
 });

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -5,13 +5,197 @@ import {
   readdirSync,
   statSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import Database from "better-sqlite3";
+import type { Database as DB } from "better-sqlite3";
 import type { AgentEvent, EventType, EventSink } from "../schema.js";
-import { riskOf } from "../schema.js";
+import { clampTs, riskOf } from "../schema.js";
 import { nextId } from "../util/ids.js";
 
 type Emit = EventSink | ((e: AgentEvent) => void);
+
+/**
+ * Cursor SQLite activity (composer sessions + prompts).
+ *
+ * Cursor (a VS Code fork) persists per-workspace state in a VS Code-style
+ * `state.vscdb` — a SQLite db with a single `ItemTable(key TEXT, value)`
+ * table. Two keys carry real AI activity:
+ *
+ *   composer.composerData  → { allComposers: [{ composerId, createdAt,
+ *                              totalLinesAdded, totalLinesRemoved,
+ *                              isArchived, ... }] } (or a bare array in
+ *                              older builds — we accept both)
+ *   aiService.prompts      → [{ text, commandType }, ...] — a flat,
+ *                              append-only history of user prompts with
+ *                              NO per-prompt timestamp and no link back to
+ *                              a composerId.
+ *
+ * What we emit (issue #2 / AUR-187 Gap 3):
+ *   - One `session_start` per composerData entry, timestamped at its
+ *     `createdAt`, carrying totalLinesAdded/Removed in `linesChanged`.
+ *   - One `prompt` per NEW entry appended to aiService.prompts, anchored
+ *     to the most-recently-created composer's `createdAt` — "rough but
+ *     real": there is no ground truth linking a given prompt to a given
+ *     composer or wall-clock time, so we anchor to the newest session as
+ *     the best available approximation.
+ *
+ * What we do NOT emit, because Cursor doesn't persist it to disk at all
+ * (confirmed by inspecting a live workspace — see docs/features/
+ * agent-detection.md): tool_call / tool_result, per-turn token usage, or
+ * cost. That data appears to live server-side only.
+ */
+
+export interface CursorComposerEntry {
+  composerId: string;
+  createdAt: number;
+  totalLinesAdded: number;
+  totalLinesRemoved: number;
+  isArchived: boolean;
+}
+
+export interface CursorPromptEntry {
+  text: string;
+  commandType?: number;
+}
+
+/** Explicit overrides (`CURSOR_DIR`, `CURSOR_WORKSPACE_STORAGE_DIR`) win —
+ *  useful for tests and non-standard installs, same convention as the
+ *  hermes adapter's `HERMES_DB_PATH`. */
+export function resolveCursorDir(): string {
+  const explicit = process.env.CURSOR_DIR?.trim();
+  if (explicit && explicit.length > 0) return explicit;
+  return join(homedir(), ".cursor");
+}
+
+export function resolveCursorWorkspaceStorageRoot(): string {
+  const explicit = process.env.CURSOR_WORKSPACE_STORAGE_DIR?.trim();
+  if (explicit && explicit.length > 0) return explicit;
+  const home = homedir();
+  return platform() === "darwin"
+    ? join(home, "Library", "Application Support", "Cursor", "User", "workspaceStorage")
+    : join(home, ".config", "Cursor", "User", "workspaceStorage");
+}
+
+export function findCursorStateDbs(root: string): string[] {
+  if (!existsSync(root)) return [];
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return [];
+  }
+  const hits: string[] = [];
+  for (const name of entries) {
+    const dbPath = join(root, name, "state.vscdb");
+    if (existsSync(dbPath)) hits.push(dbPath);
+  }
+  return hits;
+}
+
+function valueToText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) return value.toString("utf8");
+  return "";
+}
+
+export function parseCursorComposerEntries(text: string): CursorComposerEntry[] {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    const arr = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray((parsed as Record<string, unknown> | null)?.allComposers)
+        ? ((parsed as Record<string, unknown>).allComposers as unknown[])
+        : [];
+    const out: CursorComposerEntry[] = [];
+    for (const c of arr) {
+      if (!c || typeof c !== "object") continue;
+      const rec = c as Record<string, unknown>;
+      const composerId = typeof rec.composerId === "string" ? rec.composerId : undefined;
+      const createdAt = typeof rec.createdAt === "number" ? rec.createdAt : undefined;
+      if (!composerId || createdAt === undefined) continue;
+      out.push({
+        composerId,
+        createdAt,
+        totalLinesAdded: typeof rec.totalLinesAdded === "number" ? rec.totalLinesAdded : 0,
+        totalLinesRemoved: typeof rec.totalLinesRemoved === "number" ? rec.totalLinesRemoved : 0,
+        isArchived: rec.isArchived === true,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+export function parseCursorPromptEntries(text: string): CursorPromptEntry[] {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const out: CursorPromptEntry[] = [];
+    for (const p of parsed) {
+      if (!p || typeof p !== "object") continue;
+      const rec = p as Record<string, unknown>;
+      if (typeof rec.text !== "string" || rec.text.length === 0) continue;
+      out.push({
+        text: rec.text,
+        commandType: typeof rec.commandType === "number" ? rec.commandType : undefined,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function oneLineSummary(text: string, max = 140): string {
+  const oneline = text.replace(/\s+/g, " ").trim();
+  if (oneline.length <= max) return oneline;
+  return oneline.slice(0, max - 3) + "...";
+}
+
+export function translateCursorComposer(entry: CursorComposerEntry, source: string): AgentEvent {
+  const ts = clampTs(new Date(entry.createdAt).toISOString());
+  const archivedTag = entry.isArchived ? " [archived]" : "";
+  return {
+    id: nextId(),
+    ts,
+    agent: "cursor",
+    type: "session_start",
+    sessionId: entry.composerId,
+    tool: "cursor:composer",
+    riskScore: riskOf("session_start"),
+    summary:
+      `composer session ${entry.composerId.slice(0, 8)} ` +
+      `(+${entry.totalLinesAdded}/-${entry.totalLinesRemoved} lines)${archivedTag}`,
+    details: {
+      source,
+      linesChanged: { added: entry.totalLinesAdded, removed: entry.totalLinesRemoved },
+    },
+  };
+}
+
+export function translateCursorPrompt(
+  prompt: CursorPromptEntry,
+  anchor: CursorComposerEntry,
+  source: string,
+): AgentEvent {
+  const ts = clampTs(new Date(anchor.createdAt).toISOString());
+  return {
+    id: nextId(),
+    ts,
+    agent: "cursor",
+    type: "prompt",
+    sessionId: anchor.composerId,
+    tool: "cursor:prompt",
+    riskScore: riskOf("prompt"),
+    summary: oneLineSummary(prompt.text),
+    details: {
+      source,
+      fullText: prompt.text,
+    },
+  };
+}
 
 export interface CursorStatus {
   installed: boolean;
@@ -26,26 +210,36 @@ export interface CursorStatus {
 }
 
 /**
- * Cursor adapter — config-level only in v0.
+ * Cursor adapter — config surface (MCP / permissions / rules / recent
+ * files) plus real activity read from Cursor's own SQLite state
+ * (composer sessions + prompts; see the doc comment above
+ * translateCursorComposer for what that does and doesn't cover).
  *
- * Startup work is side-effect-free: we read the config and return a
- * synchronous status snapshot for the agent panel. No events emitted on
- * startup — only when files actually change. That keeps the timeline
- * reserved for real activity.
+ * Config-surface startup work is side-effect-free: we read the config and
+ * return a synchronous status snapshot for the agent panel, only emitting
+ * on subsequent file changes. The SQLite activity block below does emit
+ * on startup (backfilling composer sessions + prompts already on disk),
+ * matching the other activity adapters (hermes, claude-code, ...).
  */
 export function startCursorAdapter(
   workspace: string,
   sink: Emit,
 ): { stop: () => void; status: CursorStatus } {
   const emit = typeof sink === "function" ? sink : sink.emit;
-  const cursorDir = join(homedir(), ".cursor");
+  const cursorDir = resolveCursorDir();
   const installed = existsSync(cursorDir);
   const status: CursorStatus = {
     installed,
     mcpServers: [],
     cursorRulesFiles: [],
   };
-  if (!installed) return { stop: () => {}, status };
+  // The CLI config dir (~/.cursor) and the GUI app's activity DB
+  // (workspaceStorage/*/state.vscdb) are independent — a GUI-only user
+  // may have real activity with no ~/.cursor at all. Only bail out when
+  // BOTH are absent; otherwise run whichever surface is actually there.
+  const activityRoot = resolveCursorWorkspaceStorageRoot();
+  const activityDbs = findCursorStateDbs(activityRoot);
+  if (!installed && activityDbs.length === 0) return { stop: () => {}, status };
 
   const stoppers: Array<() => void> = [];
   const lastRecentFiles = new Set<string>();
@@ -160,6 +354,114 @@ export function startCursorAdapter(
       void w.close();
     });
   }
+
+  // 5) SQLite activity — composer sessions + prompts from every
+  //    workspaceStorage/*/state.vscdb on this machine (not scoped to the
+  //    current `workspace`, same as the claude-code/hermes adapters
+  //    scanning globally under $HOME — agentwatch's whole premise is one
+  //    cross-project timeline).
+  const dbHandles = new Map<string, DB>();
+  const seenComposerIds = new Map<string, Set<string>>();
+  const promptsEmitted = new Map<string, number>();
+  const watchedDbPaths = new Set<string>();
+  const activityWatchers: Array<ReturnType<typeof chokidar.watch>> = [];
+
+  function openCursorDb(dbPath: string): DB | null {
+    try {
+      const d = new Database(dbPath, { readonly: true, fileMustExist: true });
+      d.pragma("busy_timeout = 2000");
+      return d;
+    } catch {
+      return null;
+    }
+  }
+
+  function processCursorDb(dbPath: string): void {
+    let db = dbHandles.get(dbPath);
+    if (!db) {
+      const opened = openCursorDb(dbPath);
+      if (!opened) return;
+      db = opened;
+      dbHandles.set(dbPath, db);
+      seenComposerIds.set(dbPath, new Set());
+      promptsEmitted.set(dbPath, 0);
+    }
+
+    let composerRow: { value: unknown } | undefined;
+    let promptsRow: { value: unknown } | undefined;
+    try {
+      composerRow = db
+        .prepare("SELECT value FROM ItemTable WHERE key = 'composer.composerData'")
+        .get() as { value: unknown } | undefined;
+      promptsRow = db
+        .prepare("SELECT value FROM ItemTable WHERE key = 'aiService.prompts'")
+        .get() as { value: unknown } | undefined;
+    } catch (err) {
+      swallow(err);
+      return;
+    }
+
+    const composers = composerRow
+      ? parseCursorComposerEntries(valueToText(composerRow.value))
+      : [];
+    const seen = seenComposerIds.get(dbPath)!;
+    for (const c of composers) {
+      if (seen.has(c.composerId)) continue;
+      seen.add(c.composerId);
+      emit(translateCursorComposer(c, dbPath));
+    }
+
+    // No composer entries → no timestamp to anchor prompts to. Rather
+    // than invent one, skip (documented limitation).
+    if (composers.length === 0) return;
+
+    const anchor = composers.reduce((a, b) => (b.createdAt > a.createdAt ? b : a));
+    const prompts = promptsRow ? parseCursorPromptEntries(valueToText(promptsRow.value)) : [];
+    const alreadyEmitted = promptsEmitted.get(dbPath) ?? 0;
+    if (prompts.length > alreadyEmitted) {
+      for (let i = alreadyEmitted; i < prompts.length; i++) {
+        emit(translateCursorPrompt(prompts[i]!, anchor, dbPath));
+      }
+    }
+    // Array can only be read as a whole (no per-row id), so a shrink
+    // (history cleared) just resyncs the count — no replay.
+    promptsEmitted.set(dbPath, prompts.length);
+  }
+
+  function watchCursorDb(dbPath: string): void {
+    if (watchedDbPaths.has(dbPath)) return;
+    watchedDbPaths.add(dbPath);
+    const w = chokidar.watch([dbPath, dbPath + "-wal"], { ignoreInitial: true });
+    w.on("change", () => processCursorDb(dbPath));
+    w.on("error", swallow);
+    activityWatchers.push(w);
+  }
+
+  function rescanWorkspaceStorage(): void {
+    for (const dbPath of findCursorStateDbs(activityRoot)) {
+      processCursorDb(dbPath);
+      watchCursorDb(dbPath);
+    }
+  }
+
+  rescanWorkspaceStorage();
+  // Safety-net poll: catches new workspaces opened in Cursor after
+  // agentwatch started, and re-reads content for known dbs in case a
+  // write raced the chokidar watcher's startup (same 2s cadence as the
+  // hermes adapter's poller, for the same reason).
+  const rescanInterval = setInterval(rescanWorkspaceStorage, 2_000);
+
+  stoppers.push(() => {
+    clearInterval(rescanInterval);
+    for (const w of activityWatchers) void w.close();
+    for (const db of dbHandles.values()) {
+      try {
+        db.close();
+      } catch {
+        // better-sqlite3 close errors are non-fatal
+      }
+    }
+  });
 
   return {
     stop: () => {

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -158,7 +158,12 @@ export function translateCursorComposer(entry: CursorComposerEntry, source: stri
   const ts = clampTs(new Date(entry.createdAt).toISOString());
   const archivedTag = entry.isArchived ? " [archived]" : "";
   return {
-    id: nextId(),
+    // Deterministic — this is a backfill replayed in full on every boot
+    // (the whole ItemTable is read fresh each time, unlike the JSONL
+    // adapters' tail-window resume). A nextId() here would insert ~2k
+    // duplicate rows per restart; INSERT OR IGNORE on this id is what
+    // actually dedups.
+    id: `cursor-${entry.composerId}`,
     ts,
     agent: "cursor",
     type: "session_start",
@@ -177,12 +182,16 @@ export function translateCursorComposer(entry: CursorComposerEntry, source: stri
 
 export function translateCursorPrompt(
   prompt: CursorPromptEntry,
+  index: number,
   anchor: CursorComposerEntry,
   source: string,
 ): AgentEvent {
   const ts = clampTs(new Date(anchor.createdAt).toISOString());
   return {
-    id: nextId(),
+    // Deterministic — aiService.prompts is append-only, so a prompt's
+    // index in that array is a stable identity across restarts (same
+    // reasoning as translateCursorComposer above).
+    id: `cursor-${anchor.composerId}-p${index}`,
     ts,
     agent: "cursor",
     type: "prompt",
@@ -420,7 +429,7 @@ export function startCursorAdapter(
     const alreadyEmitted = promptsEmitted.get(dbPath) ?? 0;
     if (prompts.length > alreadyEmitted) {
       for (let i = alreadyEmitted; i < prompts.length; i++) {
-        emit(translateCursorPrompt(prompts[i]!, anchor, dbPath));
+        emit(translateCursorPrompt(prompts[i]!, i, anchor, dbPath));
       }
     }
     // Array can only be read as a whole (no per-row id), so a shrink

--- a/src/adapters/detect.ts
+++ b/src/adapters/detect.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { AgentName } from "../schema.js";
+import { findCursorStateDbs, resolveCursorWorkspaceStorageRoot } from "./cursor.js";
 
 export interface DetectedAgent {
   name: AgentName;
@@ -57,8 +58,13 @@ export function detectAgents(): DetectedAgent[] {
       name: "cursor",
       label: "Cursor",
       configPath: join(home, ".cursor", "mcp.json"),
-      present: existsSync(join(home, ".cursor")),
-      instrumented: true, // config-level only in v0; SQLite DB TBD
+      // Present if either the CLI config dir exists OR a workspaceStorage
+      // state.vscdb with real composer/prompt activity exists — the two
+      // are independent (GUI-only Cursor users may have no ~/.cursor).
+      present:
+        existsSync(join(home, ".cursor")) ||
+        findCursorStateDbs(resolveCursorWorkspaceStorageRoot()).length > 0,
+      instrumented: true,
     },
     {
       name: "gemini",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -109,6 +109,14 @@ export interface EventDetails {
    *  re-querying the adapter. Adapter populates from Claude `obj.cwd`
    *  or OpenClaw `sessionCwd`; null when the adapter has no cwd context. */
   cwd?: string;
+  /** Lines added/removed for a coarse session-level event where we only
+   *  have a totals snapshot, not a diff (e.g. Cursor's composer.composerData
+   *  rows, which carry totalLinesAdded/totalLinesRemoved but no per-turn
+   *  breakdown). */
+  linesChanged?: {
+    added: number;
+    removed: number;
+  };
   /** Activity category — one of ACTIVITY_CATEGORIES. Heuristically assigned
    *  on emit by the classify wrapper (AUR-264). Used by the per-session
    *  and per-project activity views to answer "where is my spend going?". */


### PR DESCRIPTION
## Summary

- Cursor's activity adapter now reads real AI activity from SQLite, not just config: every `workspaceStorage/*/state.vscdb` (macOS + Linux paths) is scanned for `composer.composerData` and `aiService.prompts`.
- Emits one `session_start` per composer session (timestamped at `createdAt`, lines added/removed in `details.linesChanged`), and one `prompt` event per new `aiService.prompts` entry, anchored to the most-recently-created composer's timestamp (no per-prompt timestamp exists in the source data).
- Config detection (`~/.cursor`) and activity detection (`workspaceStorage`) are now independent, so a GUI-only Cursor user with no `~/.cursor` dir still gets activity events and flips `agentwatch doctor` from "not detected" to "installed (events captured)".
- Explicitly does **not** emit tool_call, token usage, or cost — Cursor doesn't persist any of that to disk. Documented in `docs/features/agent-detection.md`.
- Adds unit tests for the pure parse/translate functions and an integration test against a synthetic `state.vscdb` (multi-workspace, live-update, and no-composer-to-anchor-to edge cases).

## Test plan

- [x] `npm test` — 420 tests pass, including new `cursor.test.ts` and `cursor.integration.test.ts`
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] Manually verified `agentwatch doctor` flips Cursor from "not detected" to "installed (events captured)" when only a synthetic `state.vscdb` with a composer session exists (no `~/.cursor` present)

Closes #2