### PR TITLE
perf: run semantic index build as a detached subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+### Performance
+- **Semantic index build no longer runs inline.** `agentwatch reindex` builds
+  the search index (BM25 + local embeddings) as a detached subprocess instead
+  of on the TUI's/web server's shared event loop; progress and cancel state
+  live in a `reindex_meta` row in `index.sqlite` that the TUI footer polls, so
+  first-run (and incremental) indexing never freezes the TUI. Fixes #1.
+
 ## [0.1.2] — 2026-05-26
 
 ### Performance

--- a/docs/features/semantic-search.md
+++ b/docs/features/semantic-search.md
@@ -1,0 +1,89 @@
+# Semantic search index
+
+Hybrid BM25 + local sentence-embedding search over every turn in every
+Claude / Codex / Gemini / OpenClaw session on disk. Runs entirely
+local — no cloud, no telemetry — with one exception documented below.
+
+## Contract
+
+**GOAL:** Build and query a local hybrid (BM25 + embedding) search index over session history without ever blocking the TUI or web server's event loop.
+**USER_VALUE:** Fuzzy, meaning-aware search across thousands of turns finds the right past conversation even when you don't remember the exact wording — and the TUI keeps responding to keys while the (1-3 min, first-run) build runs.
+**COUNTERFACTUAL:** Building the index inline (as it did before this fix) freezes every key in the TUI for the whole build — on a heavy install (5k-10k turns), that's 1-3 minutes of an unresponsive terminal.
+
+## How it works
+
+- **Storage:** `~/.agentwatch/index.sqlite` — an FTS5 virtual table for
+  BM25, a plain table of `Float32Array` embeddings (brute-force cosine,
+  fine up to ~100k rows), and a single-row `reindex_meta` table used as
+  the progress/lock channel described below.
+- **Embeddings:** `BAAI/bge-small-en-v1.5` (384-dim, ONNX, q8-quantized),
+  loaded via `@huggingface/transformers`. First use downloads ~80MB to
+  `~/.agentwatch/models/` — **the one network call this feature makes**,
+  and it only happens once a semantic search is actually requested.
+- **Ranking:** Reciprocal Rank Fusion (k=60) over BM25 rank + cosine
+  rank, so a turn that matches on both signals outranks one that only
+  matches on one.
+
+## The build always runs out-of-process
+
+The build (walk every session file → group into turns → embed → write)
+never runs inline in the TUI or in a web request handler. It's the
+`agentwatch reindex` CLI subcommand, always launched as a **detached
+subprocess**:
+
+```
+child_process.spawn(process.execPath, [...execArgv, entryScript, "reindex"], {
+  detached: true,
+  stdio: "ignore",
+}).unref()
+```
+
+- The web search route (`POST /api/search` with `mode: "semantic"`)
+  spawns it the first time semantic search is used, or when the
+  existing index has gone stale (no build in the last 15 minutes) —
+  see `shouldSpawnReindex` in `src/util/reindex-spawner.ts`. While the
+  index is empty it serves BM25-only results with a `status` message
+  instead of blocking the request.
+- It can also be run by hand: `agentwatch reindex` (add `--quiet` to
+  suppress stdout, e.g. from a cron job).
+- Re-running it is always incremental — turn ids already in the index
+  are skipped (`indexedIds()` in `src/util/semantic-index.ts`), so a
+  background re-index only embeds turns written since the last build.
+
+## Progress + cancel — the `reindex_meta` row
+
+Because the build is a separate process, progress can't be pushed back
+via a callback or IPC. Instead it writes a single-row `reindex_meta`
+table in the same sqlite file it's building — `status` (`idle` |
+`running` | `done` | `error` | `cancelled`), `pid`, `scannedFiles`,
+`queuedTurns`, `embeddedTurns`, `skippedTurns`, timestamps. Any process
+— the TUI, the web server, another CLI invocation — polls
+`readReindexMeta()` to see it.
+
+- **TUI footer** (`src/ui/App.tsx`) polls every 1.5s (only if
+  `hasIndex()` — a plain `fs.existsSync`, so users who never touch
+  semantic search pay nothing) and shows a yellow status line while
+  `status === "running"`, never a blocking overlay.
+- **Cancel:** press `x` in the TUI while a build is running, or send
+  `SIGINT`/`SIGTERM` to the `agentwatch reindex` process directly. The
+  builder checks the abort signal between files and between 32-turn
+  batches and stops there; `upsertTurns()` writes each batch inside a
+  SQLite transaction, so the db always reflects the last *fully
+  written* batch — a cancel or a hard kill never leaves a half-written
+  turn.
+- **Duplicate builds:** `claimReindexLock()` refuses to start a second
+  build while the recorded pid is still alive, so overlapping triggers
+  (e.g. two browser tabs both firing the first semantic search) don't
+  spawn a second process.
+
+## Failure modes
+
+- **Two tabs, one build.** Only the first spawns; the second sees the
+  lock held and just polls.
+- **Stale lock from a killed process.** `isPidAlive()` checks the
+  recorded pid; if it's dead, the next attempt reclaims the lock
+  instead of waiting forever.
+- **Model download fails (offline).** The build throws, `reindex_meta`
+  records `status: "error"` + the error text, and search keeps serving
+  BM25 results — semantic mode never becomes required for search to
+  work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@misha_misha/agentwatch",
-  "version": "0.0.3",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@misha_misha/agentwatch",
-      "version": "0.0.3",
+      "version": "0.1.2",
       "license": "MIT",
       "os": [
         "darwin",
@@ -3390,14 +3390,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4636,7 +4636,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,10 @@ Usage:
                               (subcommands: start | stop | status | logs)
   agentwatch hooks ...      install / uninstall / status the Claude Code hooks adapter
   agentwatch prune          drop events older than --older-than-days (default 90)
+  agentwatch reindex        build/refresh the semantic search index
+                              (runs standalone; the TUI + web UI spawn this
+                              detached instead of blocking on it — safe to
+                              run by hand too. --quiet suppresses stdout.)
   agentwatch link-candidates   dump AUR-276 session-correlation candidate pairs as JSON
                                (--session <id> to scope; --limit <n> to cap)
   agentwatch --help         show this help
@@ -42,6 +46,7 @@ Hotkeys inside the TUI:
   p       pause / resume event stream
   c       clear events
   w       open web UI in browser
+  x       cancel an in-progress semantic index build (footer shows progress)
 
 Environment:
   WORKSPACE_ROOT          override the detected workspace root
@@ -145,6 +150,13 @@ if (arg === "link-candidates") {
     store.close();
   }
   process.exit(0);
+}
+
+if (arg === "reindex") {
+  const { runReindexCli } = await import("./util/reindex-runner.js");
+  const quiet = process.argv.includes("--quiet");
+  const result = await runReindexCli({ quiet });
+  process.exit(result.code);
 }
 
 if (arg === "prune") {

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -89,18 +89,48 @@ export function registerSearchRoutes(
       };
     }
 
-    // Semantic: lazy-import so the model download only happens on first request.
+    // Semantic: lazy-import so the model download only happens once a
+    // semantic search is actually requested.
     try {
-      const { searchHybrid, hasIndex, indexStats, loadEmbedder, searchBm25Only } =
-        await import("../../util/semantic-index.js");
-      if (!hasIndex() || indexStats().vectors === 0) {
-        // Bail out to BM25 rather than blocking for a ~80MB model download
-        // on a web request. Surface a status so the UI can show a hint.
+      const {
+        searchHybrid,
+        hasIndex,
+        indexStats,
+        loadEmbedder,
+        searchBm25Only,
+        readReindexMeta,
+      } = await import("../../util/semantic-index.js");
+      const { shouldSpawnReindex, spawnDetachedReindex } = await import(
+        "../../util/reindex-spawner.js"
+      );
+
+      const idxExists = hasIndex();
+      const stats = idxExists ? indexStats() : { turns: 0, vectors: 0 };
+      const meta = readReindexMeta();
+      // The build always runs out-of-process (`agentwatch reindex`,
+      // detached + unref'd) — never inline here — so a request never
+      // blocks the shared event loop the TUI and this server share.
+      // claimReindexLock() inside the subprocess is what actually
+      // prevents duplicate concurrent builds; this is just "is it worth
+      // spawning one" so we don't fork on every keystroke.
+      if (shouldSpawnReindex(meta, idxExists, stats.vectors)) {
+        spawnDetachedReindex();
+      }
+
+      if (!idxExists || stats.vectors === 0) {
+        // Bail out to BM25 rather than blocking on the index build (which
+        // includes a one-time ~80MB model download). Surface a status so
+        // the UI can show progress instead of a silent stall.
         const hits = searchBm25Only(query, limit);
+        const fresh = readReindexMeta();
+        const status =
+          fresh.status === "running"
+            ? `semantic index building in the background (${fresh.embeddedTurns}/${fresh.queuedTurns} turns embedded so far) — showing BM25 results for now`
+            : "semantic index not built yet — a background build just started (agentwatch reindex). Showing BM25 results for now.";
         return {
           mode,
           hits: hits.map((h) => ({ kind: "semantic" as const, hit: h })),
-          status: "semantic index not built — running BM25 fallback. Build via: agentwatch (press / → semantic mode in TUI)",
+          status,
         };
       }
       const embed = await loadEmbedder();

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -34,6 +34,8 @@ import {
 } from "../store/index.js";
 import { withClaudeHookDedup } from "../adapters/hooks-dedup.js";
 import { withClassifier } from "../classify/index.js";
+import { hasIndex, readReindexMeta, type ReindexMeta } from "../util/semantic-index.js";
+import { cancelReindex } from "../util/reindex-spawner.js";
 
 /**
  * agentwatch TUI — live log tail.
@@ -334,6 +336,26 @@ export function App() {
     return () => clearInterval(handle);
   }, [store]);
 
+  // Semantic-index build progress. The build itself never runs here — it's
+  // a detached `agentwatch reindex` subprocess spawned by the web search
+  // route (or by hand). This just polls the sqlite progress row so the
+  // footer can show it without ever blocking on the build. hasIndex() is a
+  // cheap fs.existsSync so users who never touch semantic search never
+  // pay for the poll to open a db handle.
+  const [reindexMeta, setReindexMeta] = useState<ReindexMeta | null>(null);
+  useEffect(() => {
+    const poll = (): void => {
+      if (!hasIndex()) {
+        setReindexMeta(null);
+        return;
+      }
+      setReindexMeta(readReindexMeta());
+    };
+    poll();
+    const id = setInterval(poll, 1500);
+    return () => clearInterval(id);
+  }, []);
+
   const sessionSummaries = useMemo(() => summarizeBySession(anomalies), [anomalies]);
   const anomalyKey = sessionSummaries.map((s) => `${s.sessionId}:${s.headline}`).join("|");
   const bannerSuppressed = state.anomalyDismissKey === anomalyKey;
@@ -422,6 +444,16 @@ export function App() {
     if (input === "D" && anomalyKey) {
       dispatch({ type: "anomaly-dismiss", key: anomalyKey });
     }
+    if (input === "x" && reindexMeta?.status === "running") {
+      const cancelled = cancelReindex(reindexMeta);
+      dispatch({
+        type: "flash",
+        text: cancelled
+          ? "→ cancelling semantic index build…"
+          : "✗ no running reindex to cancel",
+      });
+      setTimeout(() => dispatch({ type: "flash-clear" }), 2000);
+    }
     if (key.downArrow || input === "j")
       dispatch({ type: "move", delta: 1, max: filtered.length });
     if (key.upArrow || input === "k")
@@ -502,6 +534,13 @@ export function App() {
             : "[q] quit  [w] open web UI  [/] filter  [a] agents panel  [f] cycle agent filter  [space] pause  [c] clear"}
         </Text>
         <Text dimColor>All other views (projects, sessions, search, tokens, graph, settings, trends, replay, diffs) → web UI.</Text>
+        {reindexMeta?.status === "running" && (
+          <Text color="yellow">
+            ⟳ indexing semantic search… {reindexMeta.embeddedTurns}/{reindexMeta.queuedTurns || "?"} turns
+            {"  "}({reindexMeta.scannedFiles} files scanned) — runs in the background, keys stay live{"  "}
+            <Text dimColor>[x] cancel</Text>
+          </Text>
+        )}
       </Box>
     </Box>
   );

--- a/src/util/reindex-runner.test.ts
+++ b/src/util/reindex-runner.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BuildProgress } from "./semantic-builder.js";
+
+const buildSemanticIndexMock = vi.fn<
+  (opts: {
+    onProgress?: (p: BuildProgress) => void;
+    signal?: AbortSignal;
+  }) => Promise<BuildProgress>
+>();
+
+vi.mock("./semantic-builder.js", () => ({
+  buildSemanticIndex: (opts: Parameters<typeof buildSemanticIndexMock>[0]) =>
+    buildSemanticIndexMock(opts),
+}));
+
+const { runReindex } = await import("./reindex-runner.js");
+const { readReindexMeta, _resetForTest, writeReindexMeta } = await import(
+  "./semantic-index.js"
+);
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agentwatch-reindex-"));
+  process.env.AGENTWATCH_INDEX_DB_PATH = join(dir, "index.sqlite");
+  _resetForTest();
+  buildSemanticIndexMock.mockReset();
+});
+
+afterEach(() => {
+  _resetForTest();
+  delete process.env.AGENTWATCH_INDEX_DB_PATH;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function progress(over: Partial<BuildProgress> = {}): BuildProgress {
+  return { scannedFiles: 0, queuedTurns: 0, embeddedTurns: 0, skippedTurns: 0, ...over };
+}
+
+describe("runReindex", () => {
+  it("marks the meta row done and returns code 0 on success", async () => {
+    buildSemanticIndexMock.mockImplementation(async (opts) => {
+      opts.onProgress?.(progress({ scannedFiles: 3, queuedTurns: 10, embeddedTurns: 10 }));
+      return progress({ scannedFiles: 3, queuedTurns: 10, embeddedTurns: 10 });
+    });
+
+    const result = await runReindex({ quiet: true });
+
+    expect(result.code).toBe(0);
+    expect(result.status).toBe("done");
+    const meta = readReindexMeta();
+    expect(meta.status).toBe("done");
+    expect(meta.embeddedTurns).toBe(10);
+    expect(meta.error).toBeNull();
+  });
+
+  it("writes intermediate progress as the build reports it", async () => {
+    const seen: number[] = [];
+    buildSemanticIndexMock.mockImplementation(async (opts) => {
+      opts.onProgress?.(progress({ queuedTurns: 100, embeddedTurns: 32 }));
+      seen.push(readReindexMeta().embeddedTurns);
+      opts.onProgress?.(progress({ queuedTurns: 100, embeddedTurns: 64 }));
+      seen.push(readReindexMeta().embeddedTurns);
+      return progress({ queuedTurns: 100, embeddedTurns: 64 });
+    });
+
+    await runReindex({ quiet: true });
+
+    expect(seen).toEqual([32, 64]);
+    // Intermediate writes must show status "running" so pollers (TUI
+    // footer, web route) know a build is in flight before it finishes.
+    expect(buildSemanticIndexMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the meta row cancelled (not error) when the signal aborts", async () => {
+    buildSemanticIndexMock.mockImplementation(async (opts) => {
+      opts.onProgress?.(progress({ queuedTurns: 100, embeddedTurns: 16 }));
+      // Simulate the builder noticing the abort mid-run and returning
+      // early with partial progress, as buildSemanticIndex actually does.
+      return progress({ queuedTurns: 100, embeddedTurns: 16 });
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runReindex({ signal: controller.signal, quiet: true });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.code).toBe(130);
+    const meta = readReindexMeta();
+    expect(meta.status).toBe("cancelled");
+    expect(meta.embeddedTurns).toBe(16);
+  });
+
+  it("marks the meta row error and returns code 1 when the build throws", async () => {
+    buildSemanticIndexMock.mockRejectedValue(new Error("boom"));
+
+    const result = await runReindex({ quiet: true });
+
+    expect(result.code).toBe(1);
+    expect(result.status).toBe("error");
+    const meta = readReindexMeta();
+    expect(meta.status).toBe("error");
+    expect(meta.error).toContain("boom");
+  });
+
+  it("refuses to start a second build while one is already running (lock held)", async () => {
+    writeReindexMeta({ status: "running", pid: process.pid });
+
+    const result = await runReindex({ quiet: true });
+
+    expect(result.code).toBe(0);
+    expect(result.status).toBe("running");
+    expect(buildSemanticIndexMock).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when the previously-recorded pid is dead (stale lock)", async () => {
+    writeReindexMeta({ status: "running", pid: 999_999_999 });
+    buildSemanticIndexMock.mockResolvedValue(progress());
+
+    const result = await runReindex({ quiet: true });
+
+    expect(buildSemanticIndexMock).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("done");
+  });
+});

--- a/src/util/reindex-runner.ts
+++ b/src/util/reindex-runner.ts
@@ -1,0 +1,117 @@
+import { buildSemanticIndex } from "./semantic-builder.js";
+import {
+  claimReindexLock,
+  writeReindexMeta,
+  type ReindexStatus,
+} from "./semantic-index.js";
+
+/**
+ * The actual `agentwatch reindex` work — runs standalone in a detached
+ * subprocess (spawned via reindex-spawner.ts) so it never shares an event
+ * loop with the TUI's Ink input handler or the web server. Progress is
+ * written to the index.sqlite `reindex_meta` row as it goes; any process
+ * (TUI footer, web search route) can poll `readReindexMeta()` to show it.
+ *
+ * `runReindex` is the testable core (takes an injectable AbortSignal).
+ * `runReindexCli` wires that signal to real OS signals for the actual CLI
+ * entry point — kept separate so tests never have to send a real SIGINT.
+ */
+
+export interface ReindexResult {
+  code: number;
+  message: string;
+  status: ReindexStatus;
+}
+
+export async function runReindex(
+  opts: { signal?: AbortSignal; quiet?: boolean } = {},
+): Promise<ReindexResult> {
+  const claim = claimReindexLock();
+  if (!claim.acquired) {
+    const message = `reindex already running (pid ${claim.meta.pid ?? "?"}) — skipping duplicate build`;
+    log(opts, message);
+    return { code: 0, message, status: claim.meta.status };
+  }
+
+  let cancelled = false;
+  const signal = opts.signal;
+  const onAbort = (): void => {
+    cancelled = true;
+  };
+  signal?.addEventListener("abort", onAbort);
+
+  try {
+    const progress = await buildSemanticIndex({
+      ...(signal ? { signal } : {}),
+      onProgress: (p) => {
+        writeReindexMeta({
+          status: "running",
+          scannedFiles: p.scannedFiles,
+          queuedTurns: p.queuedTurns,
+          embeddedTurns: p.embeddedTurns,
+          skippedTurns: p.skippedTurns,
+          updatedAt: new Date().toISOString(),
+        });
+      },
+    });
+    const status: ReindexStatus = cancelled || signal?.aborted ? "cancelled" : "done";
+    writeReindexMeta({
+      status,
+      scannedFiles: progress.scannedFiles,
+      queuedTurns: progress.queuedTurns,
+      embeddedTurns: progress.embeddedTurns,
+      skippedTurns: progress.skippedTurns,
+      updatedAt: new Date().toISOString(),
+      error: null,
+    });
+    const message =
+      status === "cancelled"
+        ? `reindex cancelled after embedding ${progress.embeddedTurns}/${progress.queuedTurns} turns (db left consistent)`
+        : `reindex complete: ${progress.embeddedTurns} embedded, ${progress.scannedFiles} files scanned`;
+    log(opts, message);
+    return { code: status === "cancelled" ? 130 : 0, message, status };
+  } catch (err) {
+    const message = `reindex failed: ${String(err)}`;
+    writeReindexMeta({
+      status: "error",
+      error: message.slice(0, 500),
+      updatedAt: new Date().toISOString(),
+    });
+    log(opts, message, true);
+    return { code: 1, message, status: "error" };
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+/** Real CLI entry point — wires SIGINT/SIGTERM to an AbortSignal so
+ *  Ctrl-C (or a TUI-issued SIGTERM) cancels the build cleanly instead of
+ *  killing it mid-write. Batches are committed transactionally in
+ *  semantic-builder.ts, so even a hard kill only ever loses the
+ *  in-flight (uncommitted) batch — the db is never left partially
+ *  written. */
+export async function runReindexCli(
+  opts: { quiet?: boolean } = {},
+): Promise<ReindexResult> {
+  const controller = new AbortController();
+  const onSignal = (): void => controller.abort();
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+  try {
+    return await runReindex({ signal: controller.signal, quiet: opts.quiet });
+  } finally {
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+  }
+}
+
+function log(opts: { quiet?: boolean }, message: string, isError = false): void {
+  if (opts.quiet) return;
+  if (isError) {
+    // eslint-disable-next-line no-console
+    console.error(`[agentwatch] ${message}`);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`[agentwatch] ${message}`);
+  }
+}

--- a/src/util/reindex-spawner.test.ts
+++ b/src/util/reindex-spawner.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReindexMeta } from "./semantic-index.js";
+
+const spawnMock = vi.fn();
+const unrefMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => {
+    spawnMock(...args);
+    return { unref: unrefMock };
+  },
+}));
+
+const { spawnDetachedReindex, shouldSpawnReindex, cancelReindex } = await import(
+  "./reindex-spawner.js"
+);
+
+function meta(over: Partial<ReindexMeta> = {}): ReindexMeta {
+  return {
+    status: "idle",
+    pid: null,
+    startedAt: null,
+    updatedAt: null,
+    scannedFiles: 0,
+    queuedTurns: 0,
+    embeddedTurns: 0,
+    skippedTurns: 0,
+    error: null,
+    ...over,
+  };
+}
+
+describe("spawnDetachedReindex", () => {
+  beforeEach(() => {
+    spawnMock.mockClear();
+    unrefMock.mockClear();
+  });
+
+  it("spawns detached + ignores stdio, then unrefs the child", () => {
+    spawnDetachedReindex();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, , opts] = spawnMock.mock.calls[0]!;
+    expect(opts).toMatchObject({ detached: true, stdio: "ignore" });
+    expect(unrefMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes 'reindex' as the final CLI arg", () => {
+    spawnDetachedReindex();
+    const [, args] = spawnMock.mock.calls[0]!;
+    expect((args as string[]).at(-1)).toBe("reindex");
+  });
+});
+
+describe("shouldSpawnReindex", () => {
+  it("spawns on first run (no index yet)", () => {
+    expect(shouldSpawnReindex(meta(), false, 0)).toBe(true);
+  });
+
+  it("spawns when the index exists but has zero vectors", () => {
+    expect(shouldSpawnReindex(meta({ status: "done" }), true, 0)).toBe(true);
+  });
+
+  it("does not spawn while a live pid is already running", () => {
+    const running = meta({ status: "running", pid: process.pid });
+    expect(shouldSpawnReindex(running, true, 100)).toBe(false);
+  });
+
+  it("spawns if the recorded 'running' pid is actually dead (stale lock)", () => {
+    const stale = meta({ status: "running", pid: 999_999_999 });
+    expect(shouldSpawnReindex(stale, true, 100)).toBe(true);
+  });
+
+  it("does not spawn when a fresh build just finished", () => {
+    const fresh = meta({ status: "done", updatedAt: new Date().toISOString() });
+    expect(shouldSpawnReindex(fresh, true, 100)).toBe(false);
+  });
+
+  it("spawns again once the last build is stale", () => {
+    const old = meta({
+      status: "done",
+      updatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    });
+    expect(shouldSpawnReindex(old, true, 100)).toBe(true);
+  });
+});
+
+describe("cancelReindex", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when there's no pid to cancel", () => {
+    expect(cancelReindex(meta({ status: "idle", pid: null }))).toBe(false);
+  });
+
+  it("returns false when the pid is already dead", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err = new Error("no such process") as NodeJS.ErrnoException;
+      err.code = "ESRCH";
+      throw err;
+    });
+    expect(cancelReindex(meta({ status: "running", pid: 999_999_999 }))).toBe(false);
+  });
+
+  it("sends SIGTERM to a live pid and reports success", () => {
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((pid: number, signal?: string | number) => {
+        // Signal 0 is the liveness probe used by isPidAlive; anything else
+        // is the real cancel signal we're asserting on.
+        if (signal === 0) return true;
+        expect(pid).toBe(process.pid);
+        expect(signal).toBe("SIGTERM");
+        return true;
+      });
+    expect(cancelReindex(meta({ status: "running", pid: process.pid }))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(process.pid, "SIGTERM");
+  });
+});

--- a/src/util/reindex-spawner.ts
+++ b/src/util/reindex-spawner.ts
@@ -1,0 +1,56 @@
+import { spawn } from "node:child_process";
+import { isPidAlive, type ReindexMeta } from "./semantic-index.js";
+
+/**
+ * Launches `agentwatch reindex` as a detached, fully independent process —
+ * not a worker_thread, not an inline call. It re-execs the same
+ * interpreter + entry script the current process was started with (so it
+ * works identically under the built `dist/index.js` and under `tsx
+ * src/index.tsx` in dev), then severs the parent/child relationship with
+ * `detached: true` + `unref()` so the TUI exiting doesn't kill an
+ * in-flight build, and `stdio: 'ignore'` so it never contends for the
+ * parent's stdout/stdin (which Ink owns).
+ */
+export function spawnDetachedReindex(): void {
+  const command = process.execPath;
+  const args = [...process.execArgv, process.argv[1] ?? "", "reindex"];
+  const child = spawn(command, args, {
+    detached: true,
+    stdio: "ignore",
+    env: process.env,
+  });
+  child.unref();
+}
+
+const STALE_MS = 15 * 60 * 1000;
+
+/** Decide whether a background build is worth kicking off: never while one
+ *  is already running, always on first run (no index / empty index yet),
+ *  and periodically afterward so new turns get embedded incrementally
+ *  without the caller having to track "since last build" itself. */
+export function shouldSpawnReindex(
+  meta: ReindexMeta,
+  hasIdx: boolean,
+  vectors: number,
+): boolean {
+  if (meta.status === "running" && meta.pid != null && isPidAlive(meta.pid)) {
+    return false;
+  }
+  if (!hasIdx || vectors === 0) return true;
+  if (!meta.updatedAt) return true;
+  const updatedMs = Date.parse(meta.updatedAt);
+  if (Number.isNaN(updatedMs)) return true;
+  return Date.now() - updatedMs > STALE_MS;
+}
+
+/** Cancel an in-flight reindex. Returns false if there's no live pid to
+ *  signal (nothing running, or it already exited). */
+export function cancelReindex(meta: ReindexMeta): boolean {
+  if (meta.pid == null || !isPidAlive(meta.pid)) return false;
+  try {
+    process.kill(meta.pid, "SIGTERM");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/util/semantic-index.test.ts
+++ b/src/util/semantic-index.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { rrfFuse } from "./semantic-index.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  _resetForTest,
+  claimReindexLock,
+  isPidAlive,
+  readReindexMeta,
+  rrfFuse,
+  writeReindexMeta,
+} from "./semantic-index.js";
 
 describe("rrfFuse", () => {
   it("prefers documents that appear in both rankings", () => {
@@ -40,5 +50,93 @@ describe("rrfFuse", () => {
     }));
     const fused = rrfFuse([{ hits }], 60, 5);
     expect(fused).toHaveLength(5);
+  });
+});
+
+describe("reindex progress + lock", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agentwatch-index-"));
+    process.env.AGENTWATCH_INDEX_DB_PATH = join(dir, "index.sqlite");
+    _resetForTest();
+  });
+
+  afterEach(() => {
+    _resetForTest();
+    delete process.env.AGENTWATCH_INDEX_DB_PATH;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to idle before any build has run", () => {
+    const meta = readReindexMeta();
+    expect(meta.status).toBe("idle");
+    expect(meta.pid).toBeNull();
+    expect(meta.embeddedTurns).toBe(0);
+  });
+
+  it("round-trips a written progress patch", () => {
+    writeReindexMeta({
+      status: "running",
+      pid: 12345,
+      scannedFiles: 10,
+      queuedTurns: 100,
+      embeddedTurns: 32,
+    });
+    const meta = readReindexMeta();
+    expect(meta.status).toBe("running");
+    expect(meta.pid).toBe(12345);
+    expect(meta.scannedFiles).toBe(10);
+    expect(meta.queuedTurns).toBe(100);
+    expect(meta.embeddedTurns).toBe(32);
+  });
+
+  it("merges partial patches instead of clobbering unset fields", () => {
+    writeReindexMeta({ status: "running", pid: 1, queuedTurns: 50 });
+    writeReindexMeta({ embeddedTurns: 20 });
+    const meta = readReindexMeta();
+    expect(meta.status).toBe("running");
+    expect(meta.pid).toBe(1);
+    expect(meta.queuedTurns).toBe(50);
+    expect(meta.embeddedTurns).toBe(20);
+  });
+
+  it("isPidAlive is true for the current process", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it("isPidAlive is false for a pid that doesn't exist", () => {
+    // A pid this large is never a real process.
+    expect(isPidAlive(999_999_999)).toBe(false);
+  });
+
+  it("claimReindexLock acquires the slot when idle", () => {
+    const claim = claimReindexLock();
+    expect(claim.acquired).toBe(true);
+    expect(claim.meta.pid).toBe(process.pid);
+    expect(readReindexMeta().status).toBe("running");
+  });
+
+  it("claimReindexLock refuses a second claim while one is alive", () => {
+    const first = claimReindexLock();
+    expect(first.acquired).toBe(true);
+    const second = claimReindexLock();
+    expect(second.acquired).toBe(false);
+    expect(second.meta.pid).toBe(process.pid);
+  });
+
+  it("claimReindexLock recovers a stale lock from a dead pid", () => {
+    writeReindexMeta({ status: "running", pid: 999_999_999 });
+    const claim = claimReindexLock();
+    expect(claim.acquired).toBe(true);
+    expect(claim.meta.pid).toBe(process.pid);
+  });
+
+  it("claimReindexLock re-acquires after a previous build finished", () => {
+    writeReindexMeta({ status: "done", pid: 1, embeddedTurns: 10 });
+    const claim = claimReindexLock();
+    expect(claim.acquired).toBe(true);
+    // The new claim resets counters for the fresh run.
+    expect(claim.meta.embeddedTurns).toBe(0);
   });
 });

--- a/src/util/semantic-index.ts
+++ b/src/util/semantic-index.ts
@@ -29,6 +29,13 @@ const DB_PATH = path.join(DB_DIR, "index.sqlite");
 export const MODEL_ID = "Xenova/bge-small-en-v1.5";
 export const EMBED_DIM = 384;
 
+/** Override the index db path (tests, or advanced setups). Mirrors the
+ *  HERMES_DB_PATH convention used by the Hermes adapter. */
+function resolveDbPath(): string {
+  const override = process.env.AGENTWATCH_INDEX_DB_PATH?.trim();
+  return override ? override : DB_PATH;
+}
+
 let db: DB | null = null;
 let embedderPromise: Promise<EmbedFn> | null = null;
 
@@ -64,8 +71,9 @@ export interface SearchHit {
 
 function openDb(): DB {
   if (db) return db;
-  fs.mkdirSync(DB_DIR, { recursive: true });
-  db = new Database(DB_PATH);
+  const dbPath = resolveDbPath();
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  db = new Database(dbPath);
   db.pragma("journal_mode = WAL");
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS turns_fts USING fts5(
@@ -82,6 +90,18 @@ function openDb(): DB {
     CREATE TABLE IF NOT EXISTS turns_vec (
       id TEXT PRIMARY KEY,
       embedding BLOB NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS reindex_meta (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      status TEXT NOT NULL,
+      pid INTEGER,
+      started_at TEXT,
+      updated_at TEXT,
+      scanned_files INTEGER NOT NULL DEFAULT 0,
+      queued_turns INTEGER NOT NULL DEFAULT 0,
+      embedded_turns INTEGER NOT NULL DEFAULT 0,
+      skipped_turns INTEGER NOT NULL DEFAULT 0,
+      error TEXT
     );
   `);
   return db;
@@ -128,7 +148,116 @@ export async function loadEmbedder(): Promise<EmbedFn> {
 }
 
 export function hasIndex(): boolean {
-  return fs.existsSync(DB_PATH);
+  return fs.existsSync(resolveDbPath());
+}
+
+// ─── Reindex progress + lock (used by `agentwatch reindex`) ───────────────
+//
+// The build itself runs in a detached subprocess (see
+// src/util/reindex-runner.ts + reindex-spawner.ts) so it never shares an
+// event loop with the TUI or the web server. Progress is written here, to
+// a single-row table in the same sqlite file the build writes to, so any
+// process (TUI footer, web search route, another CLI invocation) can poll
+// it without IPC.
+
+export type ReindexStatus = "idle" | "running" | "done" | "error" | "cancelled";
+
+export interface ReindexMeta {
+  status: ReindexStatus;
+  pid: number | null;
+  startedAt: string | null;
+  updatedAt: string | null;
+  scannedFiles: number;
+  queuedTurns: number;
+  embeddedTurns: number;
+  skippedTurns: number;
+  error: string | null;
+}
+
+const IDLE_META: ReindexMeta = {
+  status: "idle",
+  pid: null,
+  startedAt: null,
+  updatedAt: null,
+  scannedFiles: 0,
+  queuedTurns: 0,
+  embeddedTurns: 0,
+  skippedTurns: 0,
+  error: null,
+};
+
+/** Read the current reindex status. Safe to call even if no build has
+ *  ever run — returns the idle default. */
+export function readReindexMeta(): ReindexMeta {
+  const d = openDb();
+  const row = d
+    .prepare(
+      `SELECT status, pid,
+              started_at as startedAt, updated_at as updatedAt,
+              scanned_files as scannedFiles, queued_turns as queuedTurns,
+              embedded_turns as embeddedTurns, skipped_turns as skippedTurns,
+              error
+       FROM reindex_meta WHERE id = 1`,
+    )
+    .get() as ReindexMeta | undefined;
+  return row ?? { ...IDLE_META };
+}
+
+/** Merge `patch` into the single reindex_meta row (upsert). */
+export function writeReindexMeta(patch: Partial<ReindexMeta>): void {
+  const d = openDb();
+  const current = readReindexMeta();
+  const merged: ReindexMeta = { ...current, ...patch };
+  d.prepare(
+    `INSERT INTO reindex_meta
+       (id, status, pid, started_at, updated_at, scanned_files, queued_turns, embedded_turns, skipped_turns, error)
+     VALUES (1, @status, @pid, @startedAt, @updatedAt, @scannedFiles, @queuedTurns, @embeddedTurns, @skippedTurns, @error)
+     ON CONFLICT(id) DO UPDATE SET
+       status = excluded.status,
+       pid = excluded.pid,
+       started_at = excluded.started_at,
+       updated_at = excluded.updated_at,
+       scanned_files = excluded.scanned_files,
+       queued_turns = excluded.queued_turns,
+       embedded_turns = excluded.embedded_turns,
+       skipped_turns = excluded.skipped_turns,
+       error = excluded.error`,
+  ).run(merged);
+}
+
+/** True if `pid` refers to a live process we're allowed to see (or don't
+ *  have permission to see, which still means it's alive). */
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/** Claim the single reindex slot. Returns `acquired: false` if another
+ *  process is already running (and still alive) so callers never spawn
+ *  a second concurrent build. */
+export function claimReindexLock(): { acquired: boolean; meta: ReindexMeta } {
+  const meta = readReindexMeta();
+  if (meta.status === "running" && meta.pid != null && isPidAlive(meta.pid)) {
+    return { acquired: false, meta };
+  }
+  const now = new Date().toISOString();
+  const next: ReindexMeta = {
+    status: "running",
+    pid: process.pid,
+    startedAt: now,
+    updatedAt: now,
+    scannedFiles: 0,
+    queuedTurns: 0,
+    embeddedTurns: 0,
+    skippedTurns: 0,
+    error: null,
+  };
+  writeReindexMeta(next);
+  return { acquired: true, meta: next };
 }
 
 export function indexStats(): { turns: number; vectors: number } {

--- a/web/src/routes/Search.tsx
+++ b/web/src/routes/Search.tsx
@@ -82,7 +82,7 @@ export function SearchPage() {
             <ul className="text-xs space-y-1 inline-block text-left">
               <li><b>live</b> — substring across the current in-memory buffer (fast, recent only)</li>
               <li><b>cross</b> — ripgrep across every JSONL on disk (slow first time, thorough)</li>
-              <li><b>semantic</b> — hybrid BM25 + embedding search (fuzzy, needs the index built in the TUI first)</li>
+              <li><b>semantic</b> — hybrid BM25 + embedding search (fuzzy; first search here starts a background index build — you'll see BM25 results while it finishes)</li>
             </ul>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Semantic search's index build (walk every session file → embed each turn → write to `~/.agentwatch/index.sqlite`) used to run inline on whatever event loop triggered it, freezing the TUI for 1-3 minutes on a heavy install.
- Adds `agentwatch reindex`, always run as a detached subprocess (`spawn(..., { detached: true, stdio: 'ignore' }).unref()`) — never inline in the TUI or a web request handler.
- The web search route spawns it the first time semantic search runs (or when the index has gone stale, >15 min since the last build), and serves BM25-only results with a status message while the build catches up.
- Progress + a single-run lock live in a new `reindex_meta` row in `index.sqlite`; the TUI footer polls it every 1.5s and shows progress without a blocking overlay, and `x` cancels an in-flight build.
- Batches are written transactionally (already the case), so a cancel or hard kill always leaves the db at the last fully-committed batch — never a half-written turn.
- Incremental re-index reuses the same detached path for free, since already-indexed turn ids are skipped.

## Test plan
- [x] `npm test` — 431/431 passing, including new suites: `semantic-index.test.ts` (reindex_meta CRUD + lock), `reindex-runner.test.ts` (build success/cancel/error/lock-contention), `reindex-spawner.test.ts` (spawn shape, stale-build heuristic, cancel signal)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — server + web build clean
- [x] Manually ran the built CLI (`node dist/index.js reindex`) against an isolated `$HOME`/index path — completes and writes `reindex_meta` without needing the model download (no session files to embed)
- [ ] Manual TUI footer + cancel-key walkthrough against a real, populated `~/.agentwatch` (needs a heavy local install to see the multi-minute build; not reproducible in this sandbox)

Closes #1