### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ layout can change freely within a minor version.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-07-09
+
 ### Performance
 - **Semantic index build no longer runs inline.** `agentwatch reindex` builds
   the search index (BM25 + local embeddings) as a detached subprocess instead

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@misha_misha/agentwatch",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@misha_misha/agentwatch",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misha_misha/agentwatch",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Local-only observability + control plane for every AI coding agent on your machine. TUI live tail + browser dashboard on localhost. Unified timeline across Claude Code, Codex, Gemini CLI, Cursor, Hermes, OpenClaw — token + cost accounting, compaction + anomaly detection, SVG call graphs, diff attribution, agent-aware replay, MCP server mode, OpenTelemetry exporter. No cloud, no telemetry, no sign-in.",
   "type": "module",
   "author": "Misha Nefedov",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0 and date the changelog: Cursor activity adapter (#38), launchd + crontab scheduled-jobs surface (#37), detached `agentwatch reindex` (#39), real Gemini MCP stats/cost (#36).

## Test plan
- [x] 485/485 tests, typecheck, build green on merged main
- [x] Packed tarball installed globally: doctor detects Cursor events, `/api/cron` returns 10 launchd agents + crontab, `/api/events` live, TUI boots as v0.2.0
- [x] `agentwatch reindex` runs detached with progress meta; SIGTERM leaves index consistent (integrity_check ok)
- [ ] `npm publish` after merge + tag